### PR TITLE
feat: 매칭 사용자 설정 도메인 관련 vo, repo 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,8 @@ repositories {
         name = "GithubPackages"
         url = uri("https://maven.pkg.github.com/10jeong/common-module")
         credentials {
-            username = System.getenv("GITHUB_USERNAME") ?: findProperty("githubUsername")
-            password = System.getenv("GITHUB_TOKEN") ?: findProperty("githubToken")
+            username = System.getenv("GITHUB_USERNAME") ?: findProperty("GITHUB_USERNAME")
+            password = System.getenv("GITHUB_TOKEN") ?: findProperty("GITHUB_TOKEN")
         }
     }
 }
@@ -32,7 +32,7 @@ ext {
 }
 
 dependencies {
-    implementation 'com.yeoljeong:common-module:0.0.4-snapshot'
+    implementation 'com.yeoljeong:common-module:0.0.5'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/UserSetting.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/UserSetting.java
@@ -35,7 +35,7 @@ public class UserSetting {
 	private boolean isSmoking;
 
 	@Embedded
-	private MbtiInfo mbtiOption;
+	private MbtiInfo mbtiInfo;
 
 	public UserSetting create(
 		UUID userId,
@@ -49,7 +49,7 @@ public class UserSetting {
 		userSetting.matchingEnabled = matchingEnabled;
 		userSetting.gender = gender;
 		userSetting.isSmoking = isSmoking;
-		userSetting.mbtiOption = mbtiOption;
+		userSetting.mbtiInfo = mbtiOption;
 		return userSetting;
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/UserSetting.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/UserSetting.java
@@ -36,20 +36,4 @@ public class UserSetting {
 
 	@Embedded
 	private MbtiInfo mbtiInfo;
-
-	public UserSetting create(
-		UUID userId,
-		boolean matchingEnabled,
-		Gender gender,
-		boolean isSmoking,
-		MbtiInfo mbtiInfo
-	) {
-		UserSetting userSetting = new UserSetting();
-		userSetting.userId = userId;
-		userSetting.matchingEnabled = matchingEnabled;
-		userSetting.gender = gender;
-		userSetting.isSmoking = isSmoking;
-		userSetting.mbtiInfo = mbtiInfo;
-		return userSetting;
-	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/UserSetting.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/UserSetting.java
@@ -1,0 +1,55 @@
+package com.yeoljeong.tripmate.usersetting.domain.entity;
+
+import com.yeoljeong.tripmate.usersetting.domain.entity.constants.Gender;
+import com.yeoljeong.tripmate.usersetting.domain.entity.vo.MbtiOption;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_setting")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserSetting {
+
+	@Id
+	@Column(name = "user_id")
+	private UUID userId;
+
+	@Column(nullable = false)
+	private boolean matchingEnabled;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private Gender gender;
+
+	@Column(nullable = false)
+	private boolean isSmoking;
+
+	@Embedded
+	private MbtiOption mbtiOption;
+
+	public UserSetting create(
+		UUID userId,
+		boolean matchingEnabled,
+		Gender gender,
+		boolean isSmoking,
+		MbtiOption mbtiOption
+	) {
+		UserSetting userSetting = new UserSetting();
+		userSetting.userId = userId;
+		userSetting.matchingEnabled = matchingEnabled;
+		userSetting.gender = gender;
+		userSetting.isSmoking = isSmoking;
+		userSetting.mbtiOption = mbtiOption;
+		return userSetting;
+	}
+}

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/UserSetting.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/UserSetting.java
@@ -42,14 +42,14 @@ public class UserSetting {
 		boolean matchingEnabled,
 		Gender gender,
 		boolean isSmoking,
-		MbtiInfo mbtiOption
+		MbtiInfo mbtiInfo
 	) {
 		UserSetting userSetting = new UserSetting();
 		userSetting.userId = userId;
 		userSetting.matchingEnabled = matchingEnabled;
 		userSetting.gender = gender;
 		userSetting.isSmoking = isSmoking;
-		userSetting.mbtiInfo = mbtiOption;
+		userSetting.mbtiInfo = mbtiInfo;
 		return userSetting;
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/UserSetting.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/UserSetting.java
@@ -1,7 +1,7 @@
 package com.yeoljeong.tripmate.usersetting.domain.entity;
 
 import com.yeoljeong.tripmate.usersetting.domain.entity.constants.Gender;
-import com.yeoljeong.tripmate.usersetting.domain.entity.vo.MbtiOption;
+import com.yeoljeong.tripmate.usersetting.domain.entity.vo.MbtiInfo;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -35,14 +35,14 @@ public class UserSetting {
 	private boolean isSmoking;
 
 	@Embedded
-	private MbtiOption mbtiOption;
+	private MbtiInfo mbtiOption;
 
 	public UserSetting create(
 		UUID userId,
 		boolean matchingEnabled,
 		Gender gender,
 		boolean isSmoking,
-		MbtiOption mbtiOption
+		MbtiInfo mbtiOption
 	) {
 		UserSetting userSetting = new UserSetting();
 		userSetting.userId = userId;

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/constants/Gender.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/constants/Gender.java
@@ -1,0 +1,5 @@
+package com.yeoljeong.tripmate.usersetting.domain.entity.constants;
+
+public enum Gender {
+	MALE, FEMALE
+}

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/constants/MbtiIE.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/constants/MbtiIE.java
@@ -1,0 +1,5 @@
+package com.yeoljeong.tripmate.usersetting.domain.entity.constants;
+
+public enum MbtiIE {
+	I, E, UNKNOWN
+}

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/constants/MbtiPJ.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/constants/MbtiPJ.java
@@ -1,0 +1,5 @@
+package com.yeoljeong.tripmate.usersetting.domain.entity.constants;
+
+public enum MbtiPJ {
+	P, J, UNKNOWN
+}

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/constants/MbtiSN.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/constants/MbtiSN.java
@@ -1,0 +1,5 @@
+package com.yeoljeong.tripmate.usersetting.domain.entity.constants;
+
+public enum MbtiSN {
+	S, N, UNKNOWN
+}

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/constants/MbtiTF.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/constants/MbtiTF.java
@@ -1,0 +1,5 @@
+package com.yeoljeong.tripmate.usersetting.domain.entity.constants;
+
+public enum MbtiTF {
+	T, F, UNKNOWN
+}

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/vo/MbtiInfo.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/vo/MbtiInfo.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MbtiOption {
+public class MbtiInfo {
 
 	private static final String UNKNOWN = "UNKNOWN";
 
@@ -33,7 +33,7 @@ public class MbtiOption {
 	@Column(nullable = false)
 	private MbtiPJ mbtiPJ = MbtiPJ.UNKNOWN;
 
-	public boolean matches(MbtiOption target) {
+	public boolean matches(MbtiInfo target) {
 		return matchAxis(this.mbtiIE, target.mbtiIE)
 			&& matchAxis(this.mbtiSN, target.mbtiSN)
 			&& matchAxis(this.mbtiTF, target.mbtiTF)

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/vo/MbtiInfo.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/vo/MbtiInfo.java
@@ -34,6 +34,7 @@ public class MbtiInfo {
 	private MbtiPJ mbtiPJ = MbtiPJ.UNKNOWN;
 
 	public boolean matches(MbtiInfo target) {
+		if (target == null) return false;
 		return matchAxis(this.mbtiIE, target.mbtiIE)
 			&& matchAxis(this.mbtiSN, target.mbtiSN)
 			&& matchAxis(this.mbtiTF, target.mbtiTF)

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/vo/MbtiInfo.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/vo/MbtiInfo.java
@@ -41,7 +41,6 @@ public class MbtiInfo {
 	}
 
 	private <T extends Enum<T>> boolean matchAxis(T preference, T target) {
-		if (preference.name().equals(UNKNOWN)) return true;
 		if (target.name().equals(UNKNOWN)) return true;
 		return preference == target;
 	}

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/vo/MbtiOption.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/vo/MbtiOption.java
@@ -1,0 +1,48 @@
+package com.yeoljeong.tripmate.usersetting.domain.entity.vo;
+
+import com.yeoljeong.tripmate.usersetting.domain.entity.constants.MbtiIE;
+import com.yeoljeong.tripmate.usersetting.domain.entity.constants.MbtiPJ;
+import com.yeoljeong.tripmate.usersetting.domain.entity.constants.MbtiSN;
+import com.yeoljeong.tripmate.usersetting.domain.entity.constants.MbtiTF;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MbtiOption {
+
+	private static final String UNKNOWN = "UNKNOWN";
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private MbtiIE mbtiIE = MbtiIE.UNKNOWN;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private MbtiSN mbtiSN = MbtiSN.UNKNOWN;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private MbtiTF mbtiTF = MbtiTF.UNKNOWN;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private MbtiPJ mbtiPJ = MbtiPJ.UNKNOWN;
+
+	public boolean matches(MbtiOption target) {
+		return matchAxis(this.mbtiIE, target.mbtiIE)
+			&& matchAxis(this.mbtiSN, target.mbtiSN)
+			&& matchAxis(this.mbtiTF, target.mbtiTF)
+			&& matchAxis(this.mbtiPJ, target.mbtiPJ);
+	}
+
+	private <T extends Enum<T>> boolean matchAxis(T preference, T target) {
+		if (preference.name().equals(UNKNOWN)) return true;
+		if (target.name().equals(UNKNOWN)) return true;
+		return preference == target;
+	}
+}

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/domain/repository/UserSettingRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/domain/repository/UserSettingRepository.java
@@ -1,0 +1,5 @@
+package com.yeoljeong.tripmate.usersetting.domain.repository;
+
+public interface UserSettingRepository {
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/repository/UserSettingJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/repository/UserSettingJpaRepository.java
@@ -1,0 +1,13 @@
+package com.yeoljeong.tripmate.usersetting.infrastructure.repository;
+
+import com.yeoljeong.tripmate.usersetting.domain.repository.UserSettingRepository;
+import com.yeoljeong.tripmate.usersetting.infrastructure.repository.jpa.SpringDataUserSettingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserSettingJpaRepository implements UserSettingRepository {
+	private final SpringDataUserSettingRepository userSettingRepository;
+}
+

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/repository/jpa/SpringDataUserSettingRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/repository/jpa/SpringDataUserSettingRepository.java
@@ -1,0 +1,9 @@
+package com.yeoljeong.tripmate.usersetting.infrastructure.repository.jpa;
+
+import com.yeoljeong.tripmate.usersetting.domain.entity.UserSetting;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataUserSettingRepository extends JpaRepository<UserSetting, UUID> {
+
+}


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록

- 사용자 매칭 설정을 저장하고 조회하기 위한 기본 도메인 구조를 추가했습니다.
- `UserSetting` 엔티티를 새로 정의하여 사용자별 매칭 활성화 여부, 성별, 흡연 여부, MBTI를 관리할 수 있도록 했습니다.
- MBTI는 4개 축(`IE`, `SN`, `TF`, `PJ`)으로 분리해 enum으로 관리하며, 각 항목은 `UNKNOWN` 값을 허용하도록 구성했습니다.
- MBTI 선호 옵션 간 매칭 여부를 판단하는 기본 로직을 추가했습니다. 특정 항목이 `UNKNOWN`인 경우에는 해당 항목을 제한 조건으로 보지 않고 매칭 가능하도록 처리했습니다.
- `UserSetting` 저장소 계층의 기본 인터페이스와 JPA 구현체를 추가했습니다.
- 보일러플레이트를 줄이기 위해 lombok 추가했습니다.
- 공통 모듈 의존성 버전을 업데이트하고, GitHub Packages 인증 정보 조회 방식도 실제 환경 변수/프로퍼티 키와 맞도록 수정했습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직

- 사용자 매칭 설정 도메인 엔티티 추가
  - `UserSetting` 엔티티 생성
  - 사용자 ID를 PK로 사용
  - 매칭 활성화 여부, 성별, 흡연 여부, MBTI 정보 필드 추가

- MBTI 및 성별 관련 enum 추가
  - `Gender`
  - `MbtiIE`
  - `MbtiSN`
  - `MbtiTF`
  - `MbtiPJ`
  - 각 MBTI 축에는 `UNKNOWN` 값을 추가하여 미지정 상태를 표현할 수 있도록 구성

- MBTI 옵션 값 객체 추가
  - `MbtiInfo` 생성
  - JPA `@Embeddable`로 구성
  - 각 MBTI 축을 enum으로 저장
  - `matches()` 로직 추가
    - 선호값 또는 대상값이 `UNKNOWN`이면 해당 축은 매칭 조건에서 제외
    - 양쪽 모두 명확한 값이 있는 경우 동일한 값일 때만 매칭

- 사용자 설정 Repository 계층 추가
  - 도메인 Repository 인터페이스 `UserSettingRepository` 추가
  - JPA 구현체 `UserSettingJpaRepository` 추가
  - Spring Data JPA Repository `SpringDataUserSettingRepository` 추가
  - `UserSetting` 엔티티를 `UUID` 기반으로 관리하도록 구성

- 빌드 설정 수정
  - Lombok 의존성 추가
    - `compileOnly`
    - `annotationProcessor`
  - `common-module` 버전 업데이트
    - `0.0.4-snapshot` → `0.0.5`
  - GitHub Packages 인증 정보 조회 키 수정
    - Gradle property 조회 시 `githubUsername/githubToken` 대신 `GITHUB_USERNAME/GITHUB_TOKEN`을 사용하도록 변경

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.

- `UserSettingRepository` 도메인 인터페이스는 현재 기본 구조만 잡혀 있으며, 실제 저장/조회/수정 유스케이스가 추가될 때 메서드가 확장될 예정입니다.

- MBTI 매칭 로직에서 `UNKNOWN`은 “상관없음” 또는 “미지정”에 가까운 값으로 동작합니다.
  - 예: 선호 MBTI 항목이 `UNKNOWN`이면 해당 항목은 어떤 값이 와도 매칭됩니다.
  - 대상 MBTI 축이 `UNKNOWN`이어도 해당 항목은 매칭 실패로 보지 않습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 설정 프로필 추가 — 성별, MBTI(세부 축), 흡연 여부, 매칭 허용 여부 저장 및 관리 가능
  * MBTI 기반 호환성 매칭 지원 — 일부 항목의 미지정(UNKNOWN)을 와일드카드로 처리하는 매칭 로직 포함

* **기타**
  * 빌드 설정 및 의존성 업데이트 — 공통 모듈 버전 상향, 레포지토리 자격증명 처리 방식 갱신 및 컴파일 시 어노테이션 처리(빌드 도구용 Lombok) 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->