### PR TITLE
feat: 유저별 개인설정 단건 조회 기능 추가

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/usersetting/application/UserSettingQueryService.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/application/UserSettingQueryService.java
@@ -1,0 +1,26 @@
+package com.yeoljeong.tripmate.usersetting.application;
+
+import static com.yeoljeong.tripmate.usersetting.domain.exception.UserSettingErrorCode.NOT_FOUND_USER_SETTING;
+
+import com.yeoljeong.tripmate.exception.BusinessException;
+import com.yeoljeong.tripmate.usersetting.application.result.UserSettingResult;
+import com.yeoljeong.tripmate.usersetting.domain.entity.UserSetting;
+import com.yeoljeong.tripmate.usersetting.domain.repository.UserSettingRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserSettingQueryService {
+
+	private final UserSettingRepository userSettingRepository;
+
+	public UserSettingResult getOne(UUID userId) {
+		UserSetting setting = userSettingRepository.findByUserIdAndIsDeletedFalse(userId)
+			.orElseThrow(() -> new BusinessException(NOT_FOUND_USER_SETTING));
+		return UserSettingResult.from(setting);
+	}
+}

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/presentation/UserSettingController.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/presentation/UserSettingController.java
@@ -1,14 +1,18 @@
 package com.yeoljeong.tripmate.usersetting.presentation;
 
+import static com.yeoljeong.tripmate.response.constants.CommonSuccessCode.OK;
+import static com.yeoljeong.tripmate.usersetting.presentation.response.constants.UserSettingSuccessCode.EDIT_SUCCESS;
+
 import com.yeoljeong.tripmate.response.ApiResponse;
 import com.yeoljeong.tripmate.usersetting.application.UserSettingCommandService;
+import com.yeoljeong.tripmate.usersetting.application.UserSettingQueryService;
 import com.yeoljeong.tripmate.usersetting.presentation.request.UserSettingUpdateRequest;
 import com.yeoljeong.tripmate.usersetting.presentation.response.UserSettingResponse;
-import com.yeoljeong.tripmate.usersetting.presentation.response.constants.UserSettingSuccessCode;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -21,14 +25,28 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserSettingController {
 
 	private final UserSettingCommandService userSettingCommandService;
+	private final UserSettingQueryService userSettingQueryService;
 
 	@PutMapping
 	public ResponseEntity<ApiResponse<UserSettingResponse>> edit(
 		@RequestHeader("X-User-Id") UUID userId,
 		@Valid @RequestBody UserSettingUpdateRequest request
 	) {
-		return ResponseEntity.status(UserSettingSuccessCode.OK.getStatus()).body(
-			ApiResponse.success(UserSettingSuccessCode.OK, UserSettingResponse.from(
-				userSettingCommandService.edit(request.toCommand(userId)))));
+		return ResponseEntity.status(EDIT_SUCCESS.getStatus()).body(
+			ApiResponse.success(EDIT_SUCCESS, UserSettingResponse.from(
+				userSettingCommandService.edit(request.toCommand(userId))
+			))
+		);
+	}
+
+	@GetMapping
+	public ResponseEntity<ApiResponse<UserSettingResponse>> getMySetting(
+		@RequestHeader("X-User-Id") UUID userId
+	) {
+		return ResponseEntity.status(EDIT_SUCCESS.getStatus()).body(
+			ApiResponse.success(OK, UserSettingResponse.from(
+				userSettingQueryService.getOne(userId)
+			))
+		);
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/presentation/response/constants/UserSettingSuccessCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/presentation/response/constants/UserSettingSuccessCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum UserSettingSuccessCode implements SuccessCode {
-	OK(HttpStatus.OK, "세팅이 수정되었습니다.")
+	EDIT_SUCCESS(HttpStatus.OK, "세팅이 수정되었습니다.")
 	;
 
 	private final HttpStatus status;


### PR DESCRIPTION
### summary  
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록

- 사용자 설정 조회 기능이 추가되었습니다. 기존에는 사용자 설정을 수정하는 흐름만 제공되었지만, 이제 `X-User-Id` 헤더를 기준으로 현재 사용자의 설정 정보를 조회할 수 있습니다.
- 사용자 설정 조회 시 삭제되지 않은 설정만 조회하도록 처리했으며, 설정이 존재하지 않는 경우 공통 비즈니스 예외를 발생시키도록 구성했습니다.

### changes  
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직

- `UserSettingQueryService` 추가
  - 사용자 ID 기준으로 사용자 설정을 조회하는 query service가 추가되었습니다.
  - `findByUserIdAndIsDeletedFalse`를 사용해 삭제되지 않은 설정만 조회합니다.
  - 조회 대상이 없을 경우 `NOT_FOUND_USER_SETTING` 에러 코드로 `BusinessException`을 발생시킵니다.
  - 조회된 엔티티는 `UserSettingResult`로 변환해 반환합니다.

- `UserSettingController` 수정
  - `GET /user-settings` API가 추가되었습니다.
  - 요청 헤더의 `X-User-Id` 값을 받아 현재 사용자의 설정 정보를 조회합니다.
  - 조회 결과는 기존 응답 구조인 `ApiResponse<UserSettingResponse>` 형태로 반환합니다.

### background (or etc.)  
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 사용자 설정 조회 기능 추가 - 개인 설정 정보를 조회할 수 있습니다.

## 개선 사항
* 설정 수정 성공 메시지 명확화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->