### PR TITLE
refactor: 레이어간 의존성 분리

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/usersetting/application/dto/command/UserSettingCommand.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/application/dto/command/UserSettingCommand.java
@@ -1,18 +1,14 @@
 package com.yeoljeong.tripmate.usersetting.application.dto.command;
 
-import com.yeoljeong.tripmate.usersetting.domain.entity.constants.MbtiIE;
-import com.yeoljeong.tripmate.usersetting.domain.entity.constants.MbtiPJ;
-import com.yeoljeong.tripmate.usersetting.domain.entity.constants.MbtiSN;
-import com.yeoljeong.tripmate.usersetting.domain.entity.constants.MbtiTF;
 import java.util.UUID;
 
 public record UserSettingCommand (
 	UUID userId,
 	boolean isSmoking,
-	MbtiIE ie,
-	MbtiSN sn,
-	MbtiTF tf,
-	MbtiPJ pj
+	String ie,
+	String sn,
+	String tf,
+	String pj
 ) {
 
 }

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/application/dto/result/MbtiResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/application/dto/result/MbtiResult.java
@@ -1,18 +1,19 @@
 package com.yeoljeong.tripmate.usersetting.application.dto.result;
 
 import com.yeoljeong.tripmate.usersetting.domain.entity.UserSetting;
-import com.yeoljeong.tripmate.usersetting.domain.entity.constants.MbtiIE;
-import com.yeoljeong.tripmate.usersetting.domain.entity.constants.MbtiPJ;
-import com.yeoljeong.tripmate.usersetting.domain.entity.constants.MbtiSN;
-import com.yeoljeong.tripmate.usersetting.domain.entity.constants.MbtiTF;
 
 public record MbtiResult(
-	MbtiIE ie,
-	MbtiSN sn,
-	MbtiTF tf,
-	MbtiPJ pj
+	String ie,
+	String sn,
+	String tf,
+	String pj
 ) {
 	public static MbtiResult from(UserSetting setting) {
-		return new MbtiResult(setting.getIe(), setting.getSn(), setting.getTf(), setting.getPj());
+		return new MbtiResult(
+			setting.getIe().name(),
+			setting.getSn().name(),
+			setting.getTf().name(),
+			setting.getPj().name()
+		);
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/Mbti.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/Mbti.java
@@ -35,11 +35,11 @@ class Mbti {
 	@Column(nullable = false)
 	private MbtiPJ mbtiPJ = MbtiPJ.UNKNOWN;
 
-	protected void update(MbtiIE ie, MbtiSN sn, MbtiTF tf, MbtiPJ pj) {
-		this.mbtiIE = ie == null ? this.mbtiIE : ie;
-		this.mbtiSN = sn == null ? this.mbtiSN : sn;
-		this.mbtiTF = tf == null ? this.mbtiTF : tf;
-		this.mbtiPJ = pj == null ? this.mbtiPJ : pj;
+	protected void update(String ie, String sn, String tf, String pj) {
+		this.mbtiIE = ie == null ? this.mbtiIE : MbtiIE.valueOf(ie);
+		this.mbtiSN = sn == null ? this.mbtiSN : MbtiSN.valueOf(sn);
+		this.mbtiTF = tf == null ? this.mbtiTF : MbtiTF.valueOf(tf);
+		this.mbtiPJ = pj == null ? this.mbtiPJ : MbtiPJ.valueOf(pj);
 	}
 
 	protected boolean matches(Mbti target) {

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/UserSetting.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/domain/entity/UserSetting.java
@@ -43,10 +43,10 @@ public class UserSetting extends BaseAuditEntity {
 
 	public void update(
 		boolean isSmoking,
-		MbtiIE ie,
-		MbtiSN sn,
-		MbtiTF tf,
-		MbtiPJ pj
+		String ie,
+		String sn,
+		String tf,
+		String pj
 	) {
 		this.isSmoking = isSmoking;
 		this.mbti.update(ie, sn, tf, pj);

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/presentation/dto/request/UserSettingUpdateRequest.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/presentation/dto/request/UserSettingUpdateRequest.java
@@ -1,20 +1,21 @@
 package com.yeoljeong.tripmate.usersetting.presentation.dto.request;
 
 import com.yeoljeong.tripmate.usersetting.application.dto.command.UserSettingCommand;
-import com.yeoljeong.tripmate.usersetting.domain.entity.constants.MbtiIE;
-import com.yeoljeong.tripmate.usersetting.domain.entity.constants.MbtiPJ;
-import com.yeoljeong.tripmate.usersetting.domain.entity.constants.MbtiSN;
-import com.yeoljeong.tripmate.usersetting.domain.entity.constants.MbtiTF;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import java.util.UUID;
 
 public record UserSettingUpdateRequest(
 	@NotNull(message = "흡연 여부는 null 일 수 없습니다.")
 	Boolean isSmoking,
-	MbtiIE ie,
-	MbtiSN sn,
-	MbtiTF tf,
-	MbtiPJ pj
+	@Pattern(regexp = "[IE]", message = "I 또는 E만 입력 가능합니다.")
+	String ie,
+	@Pattern(regexp = "[SN]", message = "S 또는 N만 입력 가능합니다.")
+	String sn,
+	@Pattern(regexp = "[TF]", message = "T 또는 F만 입력 가능합니다.")
+	String tf,
+	@Pattern(regexp = "[PJ]", message = "P 또는 J만 입력 가능합니다.")
+	String pj
 ) {
 	public UserSettingCommand toCommand(UUID userId) {
 		return new UserSettingCommand(userId, isSmoking, ie, sn, tf, pj);

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/presentation/dto/response/MbtiResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/presentation/dto/response/MbtiResponse.java
@@ -10,10 +10,10 @@ public record MbtiResponse(
 ) {
 	public static MbtiResponse from(MbtiResult mbti) {
 		return new MbtiResponse(
-			mbti.ie().name(),
-			mbti.sn().name(),
-			mbti.tf().name(),
-			mbti.pj().name()
+			mbti.ie(),
+			mbti.sn(),
+			mbti.tf(),
+			mbti.pj()
 		);
 	}
 }


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 레이어간 의존성 분리
  - 표현계층 dto, 응용 계층 dto 에서 사용 중이던 도메인 레이어 enum을 사용하지 않도록 변경

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- 표현, 응용 계층에서는 String 으로 사용하고 domain 레이어에서 해당 enum으로 변경하는 로직 생성

### background (or etc.) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 사용자 설정 입력 필드의 데이터 검증 강화

이번 업데이트에서는 사용자 환경 설정 관련 내부 데이터 구조를 개선했습니다. 사용자가 입력하는 값에 대한 유효성 검사를 추가하여 데이터 무결성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->