### PR TITLE
feat: 유저 생성 이벤트를 받아 유저 별 설정 데이터 생성 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.kafka:spring-kafka'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/application/UserSettingCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/application/UserSettingCommandService.java
@@ -12,6 +12,7 @@ import com.yeoljeong.tripmate.usersetting.domain.model.UserSetting;
 import com.yeoljeong.tripmate.usersetting.domain.repository.UserSettingRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,6 +39,10 @@ public class UserSettingCommandService implements CreateUserSettingUsecase {
 		if (userSettingRepository.existsByUserIdAndIsDeletedFalse(command.userId())) {
 			throw new BusinessException(USER_SETTING_ALREADY_EXISTS);
 		}
-		userSettingRepository.save(UserSetting.create(command.userId(), command.gender()));
+		try {
+			userSettingRepository.save(UserSetting.create(command.userId(), command.gender()));
+		} catch (DataIntegrityViolationException e) {
+			throw new BusinessException(USER_SETTING_ALREADY_EXISTS);
+		}
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/application/UserSettingCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/application/UserSettingCommandService.java
@@ -1,10 +1,13 @@
 package com.yeoljeong.tripmate.usersetting.application;
 
 import static com.yeoljeong.tripmate.usersetting.domain.exception.UserSettingErrorCode.NOT_FOUND_USER_SETTING;
+import static com.yeoljeong.tripmate.usersetting.domain.exception.UserSettingErrorCode.USER_SETTING_ALREADY_EXISTS;
 
 import com.yeoljeong.tripmate.exception.BusinessException;
+import com.yeoljeong.tripmate.usersetting.application.dto.command.CreateUserSettingCommand;
 import com.yeoljeong.tripmate.usersetting.application.dto.command.UserSettingCommand;
 import com.yeoljeong.tripmate.usersetting.application.dto.result.UserSettingResult;
+import com.yeoljeong.tripmate.usersetting.application.usecase.CreateUserSettingUsecase;
 import com.yeoljeong.tripmate.usersetting.domain.model.UserSetting;
 import com.yeoljeong.tripmate.usersetting.domain.repository.UserSettingRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 @Transactional
-public class UserSettingCommandService {
+public class UserSettingCommandService implements CreateUserSettingUsecase {
 
 	private final UserSettingRepository userSettingRepository;
 
@@ -28,5 +31,13 @@ public class UserSettingCommandService {
 			command.isSmoking(), command.ie(), command.sn(), command.tf(), command.pj()
 		);
 		return UserSettingResult.from(setting);
+	}
+
+	@Override
+	public void create(CreateUserSettingCommand command) {
+		if (userSettingRepository.existsByUserIdAndIsDeletedFalse(command.userId())) {
+			throw new BusinessException(USER_SETTING_ALREADY_EXISTS);
+		}
+		userSettingRepository.save(UserSetting.create(command.userId(), command.gender()));
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/application/dto/command/CreateUserSettingCommand.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/application/dto/command/CreateUserSettingCommand.java
@@ -1,0 +1,12 @@
+package com.yeoljeong.tripmate.usersetting.application.dto.command;
+
+import java.util.UUID;
+
+public record CreateUserSettingCommand(
+	UUID userId,
+	String gender
+) {
+	public static CreateUserSettingCommand of(UUID userId, String gender) {
+		return new CreateUserSettingCommand(userId, gender);
+	}
+}

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/application/usecase/CreateUserSettingUsecase.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/application/usecase/CreateUserSettingUsecase.java
@@ -1,0 +1,7 @@
+package com.yeoljeong.tripmate.usersetting.application.usecase;
+
+import com.yeoljeong.tripmate.usersetting.application.dto.command.CreateUserSettingCommand;
+
+public interface CreateUserSettingUsecase {
+	void create(CreateUserSettingCommand command);
+}

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/domain/exception/UserSettingErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/domain/exception/UserSettingErrorCode.java
@@ -8,7 +8,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum UserSettingErrorCode implements ErrorCode {
-	NOT_FOUND_USER_SETTING(HttpStatus.NOT_FOUND, "해당 유저의 세팅 정보를 찾을 수 없습니다.")
+	NOT_FOUND_USER_SETTING(HttpStatus.NOT_FOUND, "해당 유저의 세팅 정보를 찾을 수 없습니다."),
+	USER_SETTING_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 생성된 설정이 존재합니다."),
+	USER_ID_MISSING(HttpStatus.BAD_REQUEST, "UserId가 없어 생성할 수 없습니다."),
+	GENDER_MISSING(HttpStatus.BAD_REQUEST, "Gender가 없어 생성할 수 없습니다."),
 	;
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/domain/model/UserSetting.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/domain/model/UserSetting.java
@@ -52,6 +52,16 @@ public class UserSetting extends BaseAuditEntity {
 		this.mbti.update(ie, sn, tf, pj);
 	}
 
+	public static UserSetting create(UUID userId, String gender) {
+		UserSetting setting = new UserSetting();
+		setting.userId = userId;
+		setting.gender = Gender.valueOf(gender);
+		setting.matchingEnabled = false;
+		setting.isSmoking = false;
+		setting.mbti = new Mbti();
+		return setting;
+	}
+
 	public MbtiIE getIe() {return this.getMbti().getMbtiIE();}
 
 	public MbtiSN getSn() {return this.getMbti().getMbtiSN();}

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/domain/repository/UserSettingRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/domain/repository/UserSettingRepository.java
@@ -6,4 +6,6 @@ import java.util.UUID;
 
 public interface UserSettingRepository {
 	Optional<UserSetting> findByUserIdAndIsDeletedFalse(UUID userId);
+	boolean existsByUserIdAndIsDeletedFalse(UUID userId);
+	UserSetting save(UserSetting userSetting);
 }

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/dto/CreateUserEvent.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/dto/CreateUserEvent.java
@@ -1,0 +1,13 @@
+package com.yeoljeong.tripmate.usersetting.infrastructure.dto;
+
+import com.yeoljeong.tripmate.usersetting.application.dto.command.CreateUserSettingCommand;
+import java.util.UUID;
+
+public record CreateUserEvent (
+	UUID userId,
+	String gender
+) {
+	public CreateUserSettingCommand toCommand() {
+		return CreateUserSettingCommand.of(userId, gender);
+	}
+}

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/message/UserSettingEventListener.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/message/UserSettingEventListener.java
@@ -1,0 +1,19 @@
+package com.yeoljeong.tripmate.usersetting.infrastructure.message;
+
+import com.yeoljeong.tripmate.usersetting.application.usecase.CreateUserSettingUsecase;
+import com.yeoljeong.tripmate.usersetting.infrastructure.dto.CreateUserEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserSettingEventListener {
+
+	private final CreateUserSettingUsecase usecase;
+
+	@KafkaListener(topics = "user-create")
+	public void create(CreateUserEvent event) {
+		usecase.create(event.toCommand());
+	}
+}

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/message/UserSettingEventListener.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/message/UserSettingEventListener.java
@@ -12,7 +12,10 @@ public class UserSettingEventListener {
 
 	private final CreateUserSettingUsecase usecase;
 
-	@KafkaListener(topics = "user-create")
+	@KafkaListener(
+		topics = "user-create",
+		groupId = "${spring.kafka.consumer.group-id}"
+	)
 	public void create(CreateUserEvent event) {
 		usecase.create(event.toCommand());
 	}

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/persistence/jpa/SpringDataUserSettingRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/persistence/jpa/SpringDataUserSettingRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SpringDataUserSettingRepository extends JpaRepository<UserSetting, UUID> {
 	Optional<UserSetting> findByUserIdAndIsDeletedFalse(UUID userId);
+	boolean existsByUserIdAndIsDeletedFalse(UUID userId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/persistence/repositoryimpl/UserSettingJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/persistence/repositoryimpl/UserSettingJpaRepository.java
@@ -18,5 +18,15 @@ public class UserSettingJpaRepository implements UserSettingRepository {
 	public Optional<UserSetting> findByUserIdAndIsDeletedFalse(UUID userId) {
 		return userSettingRepository.findByUserIdAndIsDeletedFalse(userId);
 	}
+
+	@Override
+	public boolean existsByUserIdAndIsDeletedFalse(UUID userId) {
+		return userSettingRepository.existsByUserIdAndIsDeletedFalse(userId);
+	}
+
+	@Override
+	public UserSetting save(UserSetting userSetting) {
+		return userSettingRepository.save(userSetting);
+	}
 }
 

--- a/src/main/resources/application-kafka.yml
+++ b/src/main/resources/application-kafka.yml
@@ -1,0 +1,14 @@
+spring:
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: user-setting-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: "com.yeoljeong.tripmate.*"
+        spring.json.value.default.type: com.yeoljeong.tripmate.usersetting.infrastructure.dto.CreateUserEvent
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -26,6 +26,9 @@ spring:
   sql:
     init:
       mode: never
+  profiles:
+    include:
+      - kafka
 server:
   port: 0
 


### PR DESCRIPTION
### summary  
> 자세한 요약, 코드 보다 PR summary를 확인하고 동료개발자가 이해할 수 있도록

- 회원 생성 이벤트를 기반으로 `UserSetting`을 자동 생성하는 흐름이 추가되었습니다.
- Kafka의 `user-create` 토픽을 구독하여 회원 생성 이벤트를 수신하고, 이벤트 데이터를 `CreateUserSettingCommand`로 변환한 뒤 유저 설정 생성 Usecase로 전달하도록 구성했습니다.
- `UserSetting` 도메인에 정적 팩토리 메서드 `create()`가 추가되어 신규 유저 설정 생성 시 기본값을 일관되게 세팅할 수 있게 되었습니다.
- 유저 설정 생성 시 중복 생성 여부를 검증하기 위한 repository 메서드가 추가되었습니다.
- 유저 설정 생성/검증 과정에서 사용할 수 있는 에러 코드가 추가되었습니다.
- 전체적으로 “회원 생성 → Kafka 이벤트 발행/수신 → 기본 유저 설정 생성” 흐름을 위한 기반 작업입니다.

---

### changes  
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직

- **생성된 파일**
  - `CreateUserSettingCommand`
    - 유저 설정 생성을 위한 command DTO가 추가되었습니다.
    - `userId`, `gender` 정보를 담고, 정적 생성 메서드 `of()`를 통해 생성할 수 있습니다.
  - `CreateUserEvent`
    - Kafka로 전달되는 회원 생성 이벤트 DTO가 추가되었습니다.
    - 이벤트 데이터를 application layer의 `CreateUserSettingCommand`로 변환하는 `toCommand()` 로직이 포함되었습니다.
  - `UserSettingEventListener`
    - Kafka `user-create` 토픽을 구독하는 이벤트 리스너가 추가되었습니다.

- **추가된 로직**
  - `UserSetting` 도메인에 `create(UUID userId, String gender)` 팩토리 메서드가 추가되었습니다.
    - 신규 유저 설정 생성 시 아래 기본값을 설정합니다.
      - `matchingEnabled = false`
      - `isSmoking = false`
      - `mbti = new Mbti()`
      - `gender = Gender.valueOf(gender)`
  - `UserSettingRepository` 계층에 유저 설정 저장 및 존재 여부 확인용 메서드가 추가되었습니다.
    - 유저별 설정 중복 생성을 방지하기 위한 기반 로직입니다.
  - 유저 설정 관련 검증 에러 코드가 추가되었습니다.
    - 유저 설정 중복 생성
    - 필수 필드 누락 등 생성/검증 상황에 대응하기 위한 에러 코드가 포함되었습니다.

- **수정된 로직**
  - `UserSetting` 객체 생성 책임이 외부 직접 세팅 방식에서 도메인 팩토리 메서드 중심으로 정리되었습니다.
  - Kafka 이벤트 DTO와 application command DTO 간 변환 로직이 분리되어, 메시지 수신 계층과 비즈니스 계층의 역할이 명확해졌습니다.

---

### background (or etc.)  
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 생성 시 성별 정보를 포함한 사용자 설정이 자동으로 생성됩니다.
  * Kafka 이벤트로 사용자 생성이 비동기 트리거됩니다.

* **개선 사항**
  * 동일 사용자에 대한 중복 설정 생성을 방지하는 검증 및 충돌 처리 로직이 추가되었습니다.
  * 설정 생성 시 입력 누락(사용자 ID, 성별)에 대한 오류 코드가 보강되었습니다.

* **설정**
  * Kafka 연결 및 소비자/생산자 기본 설정이 프로파일로 추가되어 활성화됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->