### PR TITLE
feat: kafka config 작성, retry 정책 적용

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/config/KafkaConsumerConfiguration.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/config/KafkaConsumerConfiguration.java
@@ -30,7 +30,7 @@ public class KafkaConsumerConfiguration {
 	) {
 		ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
 		factory.setConsumerFactory(consumerFactory);
-		factory.getContainerProperties().setAckMode(AckMode.MANUAL);
+		factory.getContainerProperties().setAckMode(AckMode.MANUAL_IMMEDIATE);
 		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
 			kafkaTemplate,
 			(record, ex) -> new TopicPartition(record.topic() + ".DLT", -1));
@@ -38,6 +38,7 @@ public class KafkaConsumerConfiguration {
 		backOff.setMaxAttempts(maxAttempts);
 
 		DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer, backOff);
+		errorHandler.setCommitRecovered(true);
 		factory.setCommonErrorHandler(errorHandler);
 
 		return factory;

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/config/KafkaConsumerConfiguration.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/config/KafkaConsumerConfiguration.java
@@ -1,0 +1,47 @@
+package com.yeoljeong.tripmate.usersetting.infrastructure.config;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.common.TopicPartition;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.ContainerProperties.AckMode;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.ExponentialBackOff;
+import org.springframework.util.backoff.FixedBackOff;
+
+@Configuration
+@RequiredArgsConstructor
+public class KafkaConsumerConfiguration {
+
+	@Value("${spring.retry.interval}")
+	private long retryInterval;
+
+	@Value("${spring.retry.max-attempts}")
+	private int maxAttempts;
+
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory(
+		ConsumerFactory<String, Object> consumerFactory,
+		KafkaTemplate<String, Object> kafkaTemplate
+	) {
+		ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+		factory.setConsumerFactory(consumerFactory);
+		factory.getContainerProperties().setAckMode(AckMode.MANUAL);
+		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
+			kafkaTemplate,
+			(record, ex) -> new TopicPartition(record.topic() + ".DLT", record.partition()));
+		ExponentialBackOff backOff = new ExponentialBackOff(retryInterval, 3.0);
+		backOff.setMaxAttempts(maxAttempts);
+
+		DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer, backOff);
+		factory.setCommonErrorHandler(errorHandler);
+
+		return factory;
+	}
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/config/KafkaConsumerConfiguration.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/config/KafkaConsumerConfiguration.java
@@ -12,7 +12,6 @@ import org.springframework.kafka.listener.ContainerProperties.AckMode;
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.util.backoff.ExponentialBackOff;
-import org.springframework.util.backoff.FixedBackOff;
 
 @Configuration
 @RequiredArgsConstructor
@@ -34,7 +33,7 @@ public class KafkaConsumerConfiguration {
 		factory.getContainerProperties().setAckMode(AckMode.MANUAL);
 		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
 			kafkaTemplate,
-			(record, ex) -> new TopicPartition(record.topic() + ".DLT", record.partition()));
+			(record, ex) -> new TopicPartition(record.topic() + ".DLT", -1));
 		ExponentialBackOff backOff = new ExponentialBackOff(retryInterval, 3.0);
 		backOff.setMaxAttempts(maxAttempts);
 

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/message/UserSettingEventListener.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/message/UserSettingEventListener.java
@@ -34,6 +34,7 @@ public class UserSettingEventListener {
 			} else {
 				log.error("[UserSetting] create failed (business error): userId: {}, error: {}"
 					, event.userId(), e.getMessage());
+				throw e;
 			}
 			acknowledgment.acknowledge();
 		} catch (Exception e) {

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/message/UserSettingEventListener.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/message/UserSettingEventListener.java
@@ -1,12 +1,19 @@
 package com.yeoljeong.tripmate.usersetting.infrastructure.message;
 
+import static com.yeoljeong.tripmate.usersetting.domain.exception.UserSettingErrorCode.USER_SETTING_ALREADY_EXISTS;
+
+import com.yeoljeong.tripmate.exception.BusinessException;
 import com.yeoljeong.tripmate.usersetting.application.usecase.CreateUserSettingUsecase;
 import com.yeoljeong.tripmate.usersetting.infrastructure.dto.CreateUserEvent;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class UserSettingEventListener {
 
@@ -14,9 +21,25 @@ public class UserSettingEventListener {
 
 	@KafkaListener(
 		topics = "user-create",
-		groupId = "${spring.kafka.consumer.group-id}"
+		groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "kafkaListenerContainerFactory"
 	)
-	public void create(CreateUserEvent event) {
-		usecase.create(event.toCommand());
+	public void create(@Payload CreateUserEvent event, Acknowledgment acknowledgment) {
+		try {
+			usecase.create(event.toCommand());
+			acknowledgment.acknowledge();
+		} catch (BusinessException e) {
+			if (USER_SETTING_ALREADY_EXISTS.equals(e.getErrorCode())) {
+				log.warn("[UserSetting] already exists: userId: {}", event.userId());
+			} else {
+				log.error("[UserSetting] create failed (business error): userId: {}, error: {}"
+					, event.userId(), e.getMessage());
+			}
+			acknowledgment.acknowledge();
+		} catch (Exception e) {
+			log.warn("[UserSetting] Retry scheduled for userSetting creation (unknown error): userId: {}, error: {}",
+				event.userId(), e.getMessage());
+			throw e;
+		}
 	}
 }

--- a/src/main/resources/application-kafka.yml
+++ b/src/main/resources/application-kafka.yml
@@ -1,14 +1,24 @@
 spring:
   kafka:
-    bootstrap-servers: localhost:9092
+    bootstrap-servers: ${KAFKA_BOOTSTRAPS:localhost:29092}
     consumer:
       group-id: user-setting-group
       auto-offset-reset: earliest
+      enable-auto-commit: false
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
       properties:
         spring.json.trusted.packages: "com.yeoljeong.tripmate.*"
-        spring.json.value.default.type: com.yeoljeong.tripmate.usersetting.infrastructure.dto.CreateUserEvent
+        spring.json.type.headers: true
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.type.headers: true
+
+    listener:
+      ack-mode: manual
+      missing-topics-fatal: false
+  retry:
+    interval: 1000
+    max-attempts: 3


### PR DESCRIPTION
### summary

> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록

* Kafka 소비 안정성을 개선하기 위해 **manual ack + retry + DLT 구조를 도입**
* Kafka bootstrap 서버를 환경변수 기반으로 유연하게 설정하도록 개선
* Kafka listener에서 발생하는 예외(중복 생성, 알 수 없는 오류)에 대해 **명확한 처리 전략 추가**
* 메시지 처리 실패 시 재시도 및 최종 실패 시 DLT로 전송하여 **운영 관점에서 복구 가능하도록 설계**

### changes

> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직

* KafkaConsumerConfiguration 추가 및 수정 (manual ack, DefaultErrorHandler, DLT 적용)
* ExponentialBackOff 기반 retry 정책 적용 (1s → 3s → 9s)
* DeadLetterPublishingRecoverer 설정으로 `.DLT` 토픽 전송 로직 추가
* KafkaListener에서 try-catch 기반 예외 처리 로직 추가
* BusinessException(USER_SETTING_ALREADY_EXISTS) 발생 시 무한 재시도 방지 처리
* 기타 예외 발생 시 retry → 실패 시 DLT 전송 흐름 적용
* bootstrap-servers를 환경변수 기반으로 변경 (local/docker 대응)

### background (or etc.)

> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.

* Kafka는 **at-least-once delivery**이므로 중복 메시지 처리가 반드시 고려되어야 함
* manual ack 모드에서는 반드시 성공 시점에 ack 처리 필요 (누락 시 무한 재처리 발생)
* retry는 애플리케이션 레벨이 아니라 Kafka consumer 레벨에서 수행되도록 구성됨
* DLT 토픽(`{topic}.DLT`)을 별도로 모니터링하거나 후처리 로직이 필요함
* 로컬 환경에서는 `localhost:29092`, 컨테이너 내부에서는 `kafka:9092`를 사용해야 정상 동작


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 메시지 소비에 수동 승인(Acknowledgment) 흐름을 도입해 처리 확정과 재시도 제어를 강화했습니다.
  * 처리 실패 시 토픽별 Dead-Letter Topic(DLT)으로 전송하고, 지수 백오프(초기 간격·배수·최대 시도) 기반 재시도를 적용합니다.
  * 특정 비즈니스 예외는 경고로 처리하고 소비를 확정하여 중복 처리를 방지합니다.

* **Chores**
  * Kafka 연결·직렬화(타입 헤더 사용), 생산자/소비자 설정 및 재시도 기본값을 정비해 안정성과 재시도 동작을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->