### PR TITLE
feat: 매칭 생성 기능 구현

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/matching/application/MatchingCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/MatchingCommandService.java
@@ -1,7 +1,13 @@
 package com.yeoljeong.tripmate.matching.application;
 
+import com.yeoljeong.tripmate.exception.BusinessException;
 import com.yeoljeong.tripmate.matching.application.dto.command.CreateMatchingCommand;
 import com.yeoljeong.tripmate.matching.application.dto.result.MatchingDetailResult;
+import com.yeoljeong.tripmate.matching.domain.exception.MatchingErrorCode;
+import com.yeoljeong.tripmate.matching.domain.model.Location;
+import com.yeoljeong.tripmate.matching.domain.model.Matching;
+import com.yeoljeong.tripmate.matching.domain.model.MatchingPeriod;
+import com.yeoljeong.tripmate.matching.domain.model.MatchingSetting;
 import com.yeoljeong.tripmate.matching.domain.repository.MatchingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,9 +16,24 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MatchingCommandService {
 
-	private final MatchingRepository matchingRepository;
+	private final MatchingRepository repository;
 
 	public MatchingDetailResult create(CreateMatchingCommand command) {
-		return null;
+		if (repository.existsByHostUserIdAndMatchingStatusOpen(command.userId())) {
+			throw new BusinessException(MatchingErrorCode.MATCHING_ALREADY_IN_PROGRESS);
+		}
+		Matching matching = Matching.create(
+			command.userId(),
+			command.title(),
+			command.description(),
+			Location.of(command.lat(), command.lng()),
+			MatchingPeriod.of(command.scheduledAt(), command.recruitedAt()),
+			command.chatUrl(),
+			MatchingSetting.of(
+				command.ie(), command.sn(), command.tf(), command.pj(), command.preferenceGender(), command.allowSmoking()
+			)
+		);
+
+		return MatchingDetailResult.from(repository.save(matching));
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/MatchingCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/MatchingCommandService.java
@@ -11,9 +11,11 @@ import com.yeoljeong.tripmate.matching.domain.model.MatchingSetting;
 import com.yeoljeong.tripmate.matching.domain.repository.MatchingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class MatchingCommandService {
 
 	private final MatchingRepository repository;

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/dto/command/CreateMatchingCommand.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/dto/command/CreateMatchingCommand.java
@@ -1,7 +1,29 @@
 package com.yeoljeong.tripmate.matching.application.dto.command;
 
-public record CreateMatchingCommand (
+import com.yeoljeong.tripmate.matching.domain.constants.PreferenceGender;
+import com.yeoljeong.tripmate.matching.domain.constants.PreferenceMbtiIE;
+import com.yeoljeong.tripmate.matching.domain.constants.PreferenceMbtiPJ;
+import com.yeoljeong.tripmate.matching.domain.constants.PreferenceMbtiSN;
+import com.yeoljeong.tripmate.matching.domain.constants.PreferenceMbtiTF;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
 
+public record CreateMatchingCommand (
+	UUID userId,
+	String title,
+	String description,
+	BigDecimal lat,
+	BigDecimal lng,
+	LocalDateTime scheduledAt,
+	LocalDateTime recruitedAt,
+	String chatUrl,
+	PreferenceMbtiIE ie,
+	PreferenceMbtiSN sn,
+	PreferenceMbtiTF tf,
+	PreferenceMbtiPJ pj,
+	PreferenceGender preferenceGender,
+	Boolean allowSmoking
 ) {
 
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/dto/result/MatchingDetailResult.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/dto/result/MatchingDetailResult.java
@@ -1,7 +1,35 @@
 package com.yeoljeong.tripmate.matching.application.dto.result;
 
-public record MatchingDetailResult (
+import com.yeoljeong.tripmate.matching.domain.constants.MatchingStatus;
+import com.yeoljeong.tripmate.matching.domain.model.Location;
+import com.yeoljeong.tripmate.matching.domain.model.Matching;
+import com.yeoljeong.tripmate.matching.domain.model.MatchingPeriod;
+import com.yeoljeong.tripmate.matching.domain.model.MatchingSetting;
+import java.util.UUID;
 
-){
+public record MatchingDetailResult(
+	UUID id,
+	UUID hostUserId,
+	String title,
+	String description,
+	Location location,
+	MatchingPeriod period,
+	String chatUrl,
+	MatchingStatus status,
+	MatchingSetting setting
+) {
 
+	public static MatchingDetailResult from(Matching matching) {
+		return new MatchingDetailResult(
+			matching.getId(),
+			matching.getHostUserId(),
+			matching.getTitle(),
+			matching.getDescription(),
+			matching.getLocation(),
+			matching.getMatchingPeriod(),
+			matching.getChatUrl(),
+			matching.getStatus(),
+			matching.getMatchingSetting()
+		);
+	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/domain/exception/MatchingErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/domain/exception/MatchingErrorCode.java
@@ -1,0 +1,21 @@
+package com.yeoljeong.tripmate.matching.domain.exception;
+
+import com.yeoljeong.tripmate.exception.constants.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MatchingErrorCode implements ErrorCode {
+	MATCHING_ALREADY_IN_PROGRESS(HttpStatus.CONFLICT, "이미 진행중인 매칭이 있습니다."),
+	RECRUITMENT_DEADLINE_AFTER_ACTIVITY_DATE(HttpStatus.BAD_REQUEST, "모집 마감일이 활동 예정읿 보다 늦습니다"),
+	;
+	private final HttpStatus status;
+	private final String message;
+
+	@Override
+	public int getCode() {
+		return this.status.value();
+	}
+}

--- a/src/main/java/com/yeoljeong/tripmate/matching/domain/exception/MatchingErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/domain/exception/MatchingErrorCode.java
@@ -10,6 +10,9 @@ import org.springframework.http.HttpStatus;
 public enum MatchingErrorCode implements ErrorCode {
 	MATCHING_ALREADY_IN_PROGRESS(HttpStatus.CONFLICT, "이미 진행중인 매칭이 있습니다."),
 	RECRUITMENT_DEADLINE_AFTER_ACTIVITY_DATE(HttpStatus.BAD_REQUEST, "모집 마감일이 활동 예정일보다 늦습니다"),
+	LOCATION_REQUIRED(HttpStatus.BAD_REQUEST, "위도와 경도는 모두 입력해야 합니다."),
+	INVALID_LATITUDE_RANGE(HttpStatus.BAD_REQUEST, "위도(lat)는 -90 이상 90 이하의 값이어야 합니다."),
+	INVALID_LONGITUDE_RANGE(HttpStatus.BAD_REQUEST, "경도(lng)는 -180 이상 180 이하의 값이어야 합니다."),
 	;
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/yeoljeong/tripmate/matching/domain/exception/MatchingErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/domain/exception/MatchingErrorCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum MatchingErrorCode implements ErrorCode {
 	MATCHING_ALREADY_IN_PROGRESS(HttpStatus.CONFLICT, "이미 진행중인 매칭이 있습니다."),
-	RECRUITMENT_DEADLINE_AFTER_ACTIVITY_DATE(HttpStatus.BAD_REQUEST, "모집 마감일이 활동 예정읿 보다 늦습니다"),
+	RECRUITMENT_DEADLINE_AFTER_ACTIVITY_DATE(HttpStatus.BAD_REQUEST, "모집 마감일이 활동 예정일보다 늦습니다"),
 	;
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/yeoljeong/tripmate/matching/domain/model/Location.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/domain/model/Location.java
@@ -1,5 +1,11 @@
 package com.yeoljeong.tripmate.matching.domain.model;
 
+import static com.yeoljeong.tripmate.matching.domain.exception.MatchingErrorCode.INVALID_LATITUDE_RANGE;
+import static com.yeoljeong.tripmate.matching.domain.exception.MatchingErrorCode.INVALID_LONGITUDE_RANGE;
+import static com.yeoljeong.tripmate.matching.domain.exception.MatchingErrorCode.LOCATION_REQUIRED;
+
+import com.yeoljeong.tripmate.exception.BusinessException;
+import com.yeoljeong.tripmate.matching.domain.exception.MatchingErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.math.BigDecimal;
@@ -21,6 +27,15 @@ public class Location {
 	private BigDecimal lng;
 
 	public static Location of(BigDecimal lat, BigDecimal lng) {
+		if (lat == null || lng == null) {
+			throw new BusinessException(LOCATION_REQUIRED);
+		}
+		if (lat.compareTo(BigDecimal.valueOf(-90)) < 0 || lat.compareTo(BigDecimal.valueOf(90)) > 0) {
+			throw new BusinessException(INVALID_LATITUDE_RANGE);
+		}
+		if (lng.compareTo(BigDecimal.valueOf(-180)) < 0 || lng.compareTo(BigDecimal.valueOf(180)) > 0) {
+			throw new BusinessException(INVALID_LONGITUDE_RANGE);
+		}
 		return new Location(lat, lng);
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/domain/model/Location.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/domain/model/Location.java
@@ -4,15 +4,23 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.math.BigDecimal;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-class Location {
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Location {
 
 	@Column(nullable = false, precision = 10, scale = 7)
 	private BigDecimal lat;
 
 	@Column(nullable = false, precision = 10, scale = 7)
 	private BigDecimal lng;
+
+	public static Location of(BigDecimal lat, BigDecimal lng) {
+		return new Location(lat, lng);
+	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/domain/model/Matching.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/domain/model/Matching.java
@@ -12,9 +12,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.UUID;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @Table(name = "matching")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Matching {
@@ -29,7 +31,7 @@ public class Matching {
 	@Column(nullable = false, length = 50)
 	private String title;
 
-	@Column(columnDefinition = "TEXT")
+	@Column(columnDefinition = "TEXT", nullable = false, length = 500)
 	private String description;
 
 	@Embedded
@@ -38,7 +40,7 @@ public class Matching {
 	@Embedded
 	private MatchingPeriod matchingPeriod;
 
-	@Column(length = 500)
+	@Column(length = 500, nullable = false)
 	private String chatUrl;
 
 	@Enumerated(EnumType.STRING)
@@ -47,4 +49,25 @@ public class Matching {
 
 	@Embedded
 	private MatchingSetting matchingSetting;
+
+	public static Matching create(
+		UUID userId,
+		String title,
+		String description,
+		Location location,
+		MatchingPeriod matchingPeriod,
+		String chatUrl,
+		MatchingSetting matchingSetting
+	) {
+		Matching matching = new Matching();
+		matching.hostUserId = userId;
+		matching.title = title;
+		matching.description = description == null ? "" : description;
+		matching.location = location;
+		matching.matchingPeriod = matchingPeriod;
+		matching.chatUrl = chatUrl == null ? "" : chatUrl;
+		matching.status = MatchingStatus.OPEN;
+		matching.matchingSetting = matchingSetting;
+		return matching;
+	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/domain/model/MatchingPeriod.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/domain/model/MatchingPeriod.java
@@ -1,14 +1,22 @@
 package com.yeoljeong.tripmate.matching.domain.model;
 
+import static com.yeoljeong.tripmate.matching.domain.exception.MatchingErrorCode.RECRUITMENT_DEADLINE_AFTER_ACTIVITY_DATE;
+
+import com.yeoljeong.tripmate.exception.BusinessException;
+import com.yeoljeong.tripmate.matching.domain.exception.MatchingErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-class MatchingPeriod {
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MatchingPeriod {
 
 	@Column(nullable = false)
 	private LocalDateTime scheduledAt;
@@ -16,7 +24,14 @@ class MatchingPeriod {
 	@Column(nullable = false)
 	private LocalDateTime recruitDeadline;
 
-	public boolean isExpired() {
+	public static MatchingPeriod of(LocalDateTime scheduledAt, LocalDateTime recruitDeadline) {
+		if (recruitDeadline.isAfter(scheduledAt)) {
+			throw new BusinessException(RECRUITMENT_DEADLINE_AFTER_ACTIVITY_DATE);
+		}
+		return new MatchingPeriod(scheduledAt, recruitDeadline);
+	}
+
+	boolean isExpired() {
 		return LocalDateTime.now().isAfter(recruitDeadline);
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/domain/model/MatchingSetting.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/domain/model/MatchingSetting.java
@@ -2,19 +2,21 @@ package com.yeoljeong.tripmate.matching.domain.model;
 
 import com.yeoljeong.tripmate.matching.domain.constants.PreferenceGender;
 import com.yeoljeong.tripmate.matching.domain.constants.PreferenceMbtiIE;
-import com.yeoljeong.tripmate.matching.domain.constants.PreferenceMbtiSN;
 import com.yeoljeong.tripmate.matching.domain.constants.PreferenceMbtiPJ;
+import com.yeoljeong.tripmate.matching.domain.constants.PreferenceMbtiSN;
 import com.yeoljeong.tripmate.matching.domain.constants.PreferenceMbtiTF;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-class MatchingSetting {
+public class MatchingSetting {
 
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
@@ -38,4 +40,22 @@ class MatchingSetting {
 
 	@Column(nullable = false)
 	private boolean allowSmoking;
+
+	public static MatchingSetting of (
+		PreferenceMbtiIE ie,
+		PreferenceMbtiSN sn,
+		PreferenceMbtiTF tf,
+		PreferenceMbtiPJ pj,
+		PreferenceGender gender,
+		Boolean allowSmoking
+	) {
+		MatchingSetting setting = new MatchingSetting();
+		setting.preferenceMbtiIE = ie == null ? PreferenceMbtiIE.BOTH : ie;
+		setting.preferenceMbtiSN = sn == null ? PreferenceMbtiSN.BOTH : sn;
+		setting.preferenceMbtiTF = tf == null ? PreferenceMbtiTF.BOTH : tf;
+		setting.preferenceMbtiPJ = pj == null ? PreferenceMbtiPJ.BOTH : pj;
+		setting.preferenceGender = gender == null ? PreferenceGender.BOTH : gender;
+		setting.allowSmoking = allowSmoking == null || allowSmoking;
+		return setting;
+	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/domain/repository/MatchingRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/domain/repository/MatchingRepository.java
@@ -1,5 +1,9 @@
 package com.yeoljeong.tripmate.matching.domain.repository;
 
-public interface MatchingRepository {
+import com.yeoljeong.tripmate.matching.domain.model.Matching;
+import java.util.UUID;
 
+public interface MatchingRepository {
+	boolean existsByHostUserIdAndMatchingStatusOpen(UUID hostId);
+	Matching save(Matching matching);
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/persistence/jpa/MatchingJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/persistence/jpa/MatchingJpaRepository.java
@@ -1,9 +1,10 @@
 package com.yeoljeong.tripmate.matching.infrastructure.persistence.jpa;
 
+import com.yeoljeong.tripmate.matching.domain.constants.MatchingStatus;
 import com.yeoljeong.tripmate.matching.domain.model.Matching;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MatchingJpaRepository extends JpaRepository<Matching, UUID> {
-
+	boolean existsByHostUserIdAndStatus(UUID hostId, MatchingStatus status);
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/persistence/repositoryimpl/MatchingRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/persistence/repositoryimpl/MatchingRepositoryImpl.java
@@ -1,6 +1,10 @@
 package com.yeoljeong.tripmate.matching.infrastructure.persistence.repositoryimpl;
 
+import com.yeoljeong.tripmate.matching.domain.constants.MatchingStatus;
+import com.yeoljeong.tripmate.matching.domain.model.Matching;
 import com.yeoljeong.tripmate.matching.domain.repository.MatchingRepository;
+import com.yeoljeong.tripmate.matching.infrastructure.persistence.jpa.MatchingJpaRepository;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -8,6 +12,15 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class MatchingRepositoryImpl implements MatchingRepository {
 
-	private final com.yeoljeong.tripmate.matching.infrastructure.persistence.jpa.MatchingJpaRepository matchingRepository;
+	private final MatchingJpaRepository repository;
 
+	@Override
+	public boolean existsByHostUserIdAndMatchingStatusOpen(UUID hostId) {
+		return repository.existsByHostUserIdAndStatus(hostId, MatchingStatus.OPEN);
+	}
+
+	@Override
+	public Matching save(Matching matching) {
+		return repository.save(matching);
+	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/presentation/MatchingController.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/presentation/MatchingController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,6 +23,7 @@ public class MatchingController {
 
 	private final MatchingCommandService commandService;
 
+	@PostMapping
 	public ResponseEntity<ApiResponse<MatchingDetailResponse>> create(
 		@RequestHeader("X-User-Id") UUID userId,
 		@Valid @RequestBody CreateMatchingRequest request

--- a/src/main/java/com/yeoljeong/tripmate/matching/presentation/dto/request/CreateMatchingRequest.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/presentation/dto/request/CreateMatchingRequest.java
@@ -1,31 +1,56 @@
 package com.yeoljeong.tripmate.matching.presentation.dto.request;
 
 import com.yeoljeong.tripmate.matching.application.dto.command.CreateMatchingCommand;
-import com.yeoljeong.tripmate.matching.domain.constants.MatchingStatus;
+import com.yeoljeong.tripmate.matching.domain.constants.PreferenceGender;
 import com.yeoljeong.tripmate.matching.domain.constants.PreferenceMbtiIE;
 import com.yeoljeong.tripmate.matching.domain.constants.PreferenceMbtiPJ;
 import com.yeoljeong.tripmate.matching.domain.constants.PreferenceMbtiSN;
 import com.yeoljeong.tripmate.matching.domain.constants.PreferenceMbtiTF;
+import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import org.hibernate.validator.constraints.Length;
 
 public record CreateMatchingRequest(
-	UUID id,
-	UUID hostUserId,
+	@NotNull
+	@Length(min = 4, max = 50)
 	String title,
+	@Length(max = 500)
+	String description,
+	@NotNull
 	BigDecimal lat,
+	@NotNull
 	BigDecimal lng,
+	@NotNull
 	LocalDateTime scheduledAt,
+	@NotNull
 	LocalDateTime recruitedAt,
-	MatchingStatus status,
+	String chatUrl,
 	PreferenceMbtiIE ie,
 	PreferenceMbtiSN sn,
 	PreferenceMbtiTF tf,
-	PreferenceMbtiPJ pj
+	PreferenceMbtiPJ pj,
+	PreferenceGender preferenceGender,
+	Boolean allowSmoking
 ) {
 
 	public CreateMatchingCommand toCommand(UUID userId) {
-		return new CreateMatchingCommand();
+		return new CreateMatchingCommand(
+			userId,
+			title,
+			description,
+			lat,
+			lng,
+			scheduledAt,
+			recruitedAt,
+			chatUrl,
+			ie,
+			sn,
+			tf,
+			pj,
+			preferenceGender,
+			allowSmoking
+		);
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/presentation/dto/response/MatchingDetailResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/presentation/dto/response/MatchingDetailResponse.java
@@ -1,12 +1,45 @@
 package com.yeoljeong.tripmate.matching.presentation.dto.response;
 
 import com.yeoljeong.tripmate.matching.application.dto.result.MatchingDetailResult;
+import com.yeoljeong.tripmate.matching.domain.constants.PreferenceGender;
+import com.yeoljeong.tripmate.matching.domain.constants.PreferenceMbtiIE;
+import com.yeoljeong.tripmate.matching.domain.constants.PreferenceMbtiPJ;
+import com.yeoljeong.tripmate.matching.domain.constants.PreferenceMbtiSN;
+import com.yeoljeong.tripmate.matching.domain.constants.PreferenceMbtiTF;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
 
 public record MatchingDetailResponse (
-
+	UUID id,
+	String title,
+	String description,
+	BigDecimal lat,
+	BigDecimal lng,
+	LocalDateTime scheduledAt,
+	LocalDateTime recruitDeadline,
+	String chatUrl,
+	PreferenceMbtiIE ie,
+	PreferenceMbtiSN sn,
+	PreferenceMbtiTF tf,
+	PreferenceMbtiPJ pj,
+	PreferenceGender gender,
+	Boolean allowSmoking
 ){
-
 	public static MatchingDetailResponse from(MatchingDetailResult result) {
-		return null;
+		return new MatchingDetailResponse(
+			result.id(),
+			result.title(),
+			result.description(),
+			result.location().getLat(), result.location().getLng(),
+			result.period().getScheduledAt(), result.period().getRecruitDeadline(),
+			result.chatUrl(),
+			result.setting().getPreferenceMbtiIE(),
+			result.setting().getPreferenceMbtiSN(),
+			result.setting().getPreferenceMbtiTF(),
+			result.setting().getPreferenceMbtiPJ(),
+			result.setting().getPreferenceGender(),
+			result.setting().isAllowSmoking()
+		);
 	}
 }


### PR DESCRIPTION
### summary

> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록

* 매칭 생성 API 흐름을 Controller → Command → Domain → Repository → Response까지 연결
* 진행 중인 매칭 중복 생성 방지와 모집 마감일 검증을 추가
* Matching 도메인과 VO 생성 방식을 팩토리 메서드 기반으로 정리
* 매칭 생성 후 상세 응답을 반환할 수 있도록 응답 DTO를 정의

### changes

> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직

* MatchingRepository의 `save`, `exists` 명세 정의 및 구현
* 이미 진행 중인 매칭 존재 시 발생하는 에러 코드 추가
* 모집 마감일이 활동 예정일보다 늦을 때 발생하는 에러 코드 추가
* VO 클래스 접근 제어자 변경 및 생성 팩토리 메서드 정의
* Matching 도메인 생성 팩토리 메서드 정의
* 매칭 생성 요청 DTO에 Validation 추가
* 요청 DTO의 `toCommand()` 변환 로직 추가
* 누락된 `@PostMapping` 추가
* 매칭 생성 UseCase/Service 로직 작성
* 매칭 상세 응답 DTO 정의

### background (or etc.)

> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.

* 동일 호스트가 이미 진행 중인 매칭을 가진 경우 추가 생성이 제한됨
* 모집 마감일은 활동 예정일보다 이전이어야 함
* 요청 값은 Controller 계층에서 DTO Validation을 통해 1차 검증됨
* 도메인 생성은 생성자 직접 호출이 아니라 팩토리 메서드를 통해 수행됨
* 매칭 상태 기준과 중복 생성 정책은 추후 상태값이 늘어나면 함께 재검토 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리즈 노트

* **새로운 기능**
  * 여행 매칭 생성 기능 추가: 위치, 일정, 선호도(MBTI·성별), 채팅 URL, 흡연 허용 여부 등을 포함해 매칭을 생성할 수 있습니다.
  * 매칭 상세 응답 제공: 생성된 매칭의 상세 정보를 반환합니다.

* **버그 수정 / 동작 개선**
  * 중복 매칭 방지: 이미 진행 중인 매칭이 있는 경우 새 매칭 생성을 차단합니다.
  * 입력 유효성 강화: 위치 좌표, 모집 마감일 등 유효성 검증이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->