### PR TITLE
feat: 사용자 매칭 활성화/비활성화 기능 추가

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/matching/presentation/MatchingController.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/presentation/MatchingController.java
@@ -2,6 +2,8 @@ package com.yeoljeong.tripmate.matching.presentation;
 
 import static com.yeoljeong.tripmate.response.constants.CommonSuccessCode.CREATE;
 
+import com.yeoljeong.tripmate.auth.LoginUser;
+import com.yeoljeong.tripmate.auth.UserContext;
 import com.yeoljeong.tripmate.matching.application.MatchingCommandService;
 import com.yeoljeong.tripmate.matching.presentation.dto.request.CreateMatchingRequest;
 import com.yeoljeong.tripmate.matching.presentation.dto.response.MatchingDetailResponse;
@@ -12,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,12 +26,12 @@ public class MatchingController {
 
 	@PostMapping
 	public ResponseEntity<ApiResponse<MatchingDetailResponse>> create(
-		@RequestHeader("X-User-Id") UUID userId,
+		@LoginUser UserContext userContext,
 		@Valid @RequestBody CreateMatchingRequest request
 	) {
 		return ResponseEntity.status(CREATE.getStatus()).body(
 			ApiResponse.success(CREATE, MatchingDetailResponse.from(
-				commandService.create(request.toCommand(userId))
+				commandService.create(request.toCommand(UUID.fromString(userContext.userId())))
 			))
 		);
 	}

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/application/UserSettingCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/application/UserSettingCommandService.java
@@ -10,6 +10,7 @@ import com.yeoljeong.tripmate.usersetting.application.dto.result.UserSettingResu
 import com.yeoljeong.tripmate.usersetting.application.usecase.CreateUserSettingUsecase;
 import com.yeoljeong.tripmate.usersetting.domain.model.UserSetting;
 import com.yeoljeong.tripmate.usersetting.domain.repository.UserSettingRepository;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -44,5 +45,17 @@ public class UserSettingCommandService implements CreateUserSettingUsecase {
 		} catch (DataIntegrityViolationException e) {
 			throw new BusinessException(USER_SETTING_ALREADY_EXISTS);
 		}
+	}
+
+	public void activateMatching(UUID userId) {
+		UserSetting setting = userSettingRepository.findByUserIdAndIsDeletedFalse(userId)
+			.orElseThrow(() -> new BusinessException(NOT_FOUND_USER_SETTING));
+		setting.activateMatching();
+	}
+
+	public void deactivateMatching(UUID userId) {
+		UserSetting setting = userSettingRepository.findByUserIdAndIsDeletedFalse(userId)
+			.orElseThrow(() -> new BusinessException(NOT_FOUND_USER_SETTING));
+		setting.deactivateMatching();
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/domain/model/UserSetting.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/domain/model/UserSetting.java
@@ -46,7 +46,7 @@ public class UserSetting extends BaseAuditEntity {
 	}
 
 	public void deactivateMatching() {
-		this.matchingEnabled = true;
+		this.matchingEnabled = false;
 	}
 
 	public void update(

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/domain/model/UserSetting.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/domain/model/UserSetting.java
@@ -41,6 +41,14 @@ public class UserSetting extends BaseAuditEntity {
 	@Embedded
 	private Mbti mbti;
 
+	public void activateMatching() {
+		this.matchingEnabled = true;
+	}
+
+	public void deactivateMatching() {
+		this.matchingEnabled = true;
+	}
+
 	public void update(
 		boolean isSmoking,
 		String ie,

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/presentation/UserSettingController.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/presentation/UserSettingController.java
@@ -1,8 +1,12 @@
 package com.yeoljeong.tripmate.usersetting.presentation;
 
 import static com.yeoljeong.tripmate.response.constants.CommonSuccessCode.OK;
+import static com.yeoljeong.tripmate.usersetting.presentation.dto.response.constants.UserSettingSuccessCode.ACTIVATE_MATCHING;
+import static com.yeoljeong.tripmate.usersetting.presentation.dto.response.constants.UserSettingSuccessCode.DEACTIVATE_MATCHING;
 import static com.yeoljeong.tripmate.usersetting.presentation.dto.response.constants.UserSettingSuccessCode.EDIT_SUCCESS;
 
+import com.yeoljeong.tripmate.auth.LoginUser;
+import com.yeoljeong.tripmate.auth.UserContext;
 import com.yeoljeong.tripmate.response.ApiResponse;
 import com.yeoljeong.tripmate.usersetting.application.UserSettingCommandService;
 import com.yeoljeong.tripmate.usersetting.application.UserSettingQueryService;
@@ -13,6 +17,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -47,6 +52,26 @@ public class UserSettingController {
 			ApiResponse.success(OK, UserSettingResponse.from(
 				userSettingQueryService.getOne(userId)
 			))
+		);
+	}
+
+	@PatchMapping("/activation")
+	public ResponseEntity<ApiResponse<Void>> activateMatching(
+		@LoginUser UserContext userContext
+	) {
+		userSettingCommandService.activateMatching(UUID.fromString(userContext.userId()));
+		return ResponseEntity.status(EDIT_SUCCESS.getStatus()).body(
+			ApiResponse.success(ACTIVATE_MATCHING, null)
+		);
+	}
+
+	@PatchMapping("/deactivation")
+	public ResponseEntity<ApiResponse<Void>> deactivateMatching(
+		@LoginUser UserContext userContext
+	) {
+		userSettingCommandService.deactivateMatching(UUID.fromString(userContext.userId()));
+		return ResponseEntity.status(EDIT_SUCCESS.getStatus()).body(
+			ApiResponse.success(DEACTIVATE_MATCHING, null)
 		);
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/presentation/dto/response/constants/UserSettingSuccessCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/presentation/dto/response/constants/UserSettingSuccessCode.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum UserSettingSuccessCode implements SuccessCode {
-	EDIT_SUCCESS(HttpStatus.OK, "세팅이 수정되었습니다.")
+	EDIT_SUCCESS(HttpStatus.OK, "세팅이 수정되었습니다."),
+	ACTIVATE_MATCHING(HttpStatus.OK, "매칭 활성화 성공"),
+	DEACTIVATE_MATCHING(HttpStatus.OK, "매칭 비활성화 성공"),
 	;
 
 	private final HttpStatus status;


### PR DESCRIPTION
### summary

> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록

* 사용자 매칭 활성화/비활성화 기능을 API 단위로 분리하여 구현했다.
* 기존처럼 상태를 토글하는 방식이 아니라, 명시적으로 활성화/비활성화를 요청하는 구조로 변경했다.
* requestHeader 관련 불필요한 로직을 제거하여 API 책임을 단순화했다.

### changes

> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직

* requestHeader 제거 (불필요한 헤더 의존 로직 삭제)
* 사용자 매칭 활성화 API 추가
* 사용자 매칭 비활성화 API 추가
* 매칭 상태 변경 로직(Service 레이어) 구현
* 성공 응답 코드(SuccessCode) 정의 및 적용

### background (or etc.)

> 동료 개발자가 알아야할 사항


relate to #35 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 매칭 활성화/비활성화 기능이 추가되었습니다.
  * 사용자 설정에서 매칭 상태를 변경하는 새 PATCH API가 제공됩니다.

* **개선 사항**
  * 매칭 생성 및 사용자 설정 관련 요청에서 사용자 식별을 서버측 사용자 컨텍스트로 처리하도록 인증 흐름이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->