### PR TITLE
feat: 매칭 수락 기능 추가

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/matching/application/MatchingCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/MatchingCommandService.java
@@ -11,6 +11,7 @@ import com.yeoljeong.tripmate.matching.domain.model.MatchingPeriod;
 import com.yeoljeong.tripmate.matching.domain.model.MatchingSetting;
 import com.yeoljeong.tripmate.matching.domain.repository.MatchingRepository;
 import java.security.NoSuchAlgorithmException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,5 +44,12 @@ public class MatchingCommandService {
 		Matching saved = repository.save(matching);
 		publisher.publishMatchingCreated(saved);
 		return MatchingDetailResult.from(saved);
+	}
+
+	public void accept(UUID userId, UUID matchingId) {
+		Matching matching = repository.findByIdAndIsDeletedFalse(matchingId)
+			.orElseThrow(() -> new BusinessException(MatchingErrorCode.NO_ACTIVE_MATCHING));
+		matching.accept(userId);
+		publisher.publishMatchingAccomplished(matching);
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/SseSubscriptionService.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/SseSubscriptionService.java
@@ -6,6 +6,7 @@ import com.yeoljeong.tripmate.matching.application.external.MatchingSseManager;
 import com.yeoljeong.tripmate.matching.domain.model.Matching;
 import com.yeoljeong.tripmate.matching.domain.repository.MatchingRepository;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,5 +33,10 @@ public class SseSubscriptionService {
 			matching -> candidateNotifier.publishToUserDirect(command.userId(), matching)
 		);
 		return emitter;
+	}
+
+	@Transactional(readOnly = true)
+	public SseEmitter subscribe(UUID userId) {
+		return sseManager.subscribe(userId);
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/external/MatchingEventPublisher.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/external/MatchingEventPublisher.java
@@ -5,4 +5,5 @@ import java.security.NoSuchAlgorithmException;
 
 public interface MatchingEventPublisher {
 	void publishMatchingCreated(Matching matching) throws NoSuchAlgorithmException;
+	void publishMatchingAccomplished(Matching matching);
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/domain/exception/MatchingErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/domain/exception/MatchingErrorCode.java
@@ -14,6 +14,8 @@ public enum MatchingErrorCode implements ErrorCode {
 	INVALID_LATITUDE_RANGE(HttpStatus.BAD_REQUEST, "위도(lat)는 -90 이상 90 이하의 값이어야 합니다."),
 	INVALID_LONGITUDE_RANGE(HttpStatus.BAD_REQUEST, "경도(lng)는 -180 이상 180 이하의 값이어야 합니다."),
 	NO_ACTIVE_MATCHING(HttpStatus.NOT_FOUND, "진행 중인 매칭정보가 없습니다."),
+	HOST_CANNOT_ACCEPT_OWN_MATCHING(HttpStatus.BAD_REQUEST, "호스트 본인의 매칭을 수락할 수 없습니다."),
+	MATCHING_ALREADY_MATCHED(HttpStatus.CONFLICT, "이미 매칭이 완성된 방입니다"),
 	;
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/yeoljeong/tripmate/matching/domain/model/Matching.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/domain/model/Matching.java
@@ -1,6 +1,10 @@
 package com.yeoljeong.tripmate.matching.domain.model;
 
+import static com.yeoljeong.tripmate.matching.domain.exception.MatchingErrorCode.HOST_CANNOT_ACCEPT_OWN_MATCHING;
+import static com.yeoljeong.tripmate.matching.domain.exception.MatchingErrorCode.MATCHING_ALREADY_MATCHED;
+
 import com.yeoljeong.tripmate.domain.BaseAuditEntity;
+import com.yeoljeong.tripmate.exception.BusinessException;
 import com.yeoljeong.tripmate.matching.domain.constants.MatchingStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -28,6 +32,9 @@ public class Matching extends BaseAuditEntity {
 
 	@Column(nullable = false)
 	private UUID hostUserId;
+
+	@Column
+	private UUID mateUserId;
 
 	@Column(nullable = false, length = 50)
 	private String title;
@@ -70,5 +77,16 @@ public class Matching extends BaseAuditEntity {
 		matching.status = MatchingStatus.OPEN;
 		matching.matchingSetting = matchingSetting;
 		return matching;
+	}
+
+	public void accept(UUID userId) {
+		if (this.hostUserId.equals(userId)) {
+			throw new BusinessException(HOST_CANNOT_ACCEPT_OWN_MATCHING);
+		}
+		if (this.status == MatchingStatus.MATCHED) {
+			throw new BusinessException(MATCHING_ALREADY_MATCHED);
+		}
+		this.mateUserId = userId;
+		this.status = MatchingStatus.MATCHED;
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/domain/repository/MatchingRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/domain/repository/MatchingRepository.java
@@ -11,4 +11,5 @@ public interface MatchingRepository {
 	Matching save(Matching matching);
 	List<Matching> findAllByCriteria(UUID userId, String gender, boolean isSmoking,
 		String mbtiIE, String mbtiSN, String mbtiTF, String mbtiPJ);
+	Optional<Matching> findByIdAndIsDeletedFalse(UUID matchingId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/message/MatchingEventKafkaPublisher.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/message/MatchingEventKafkaPublisher.java
@@ -38,7 +38,8 @@ public class MatchingEventKafkaPublisher implements MatchingEventPublisher {
 		kafkaTemplate.send(MatchingTopic.MATCHING_MATCHED_TOPIC, event.matchingId().toString(), event)
 			.whenComplete((result, ex) -> {
 				if (ex != null) {
-					log.error("[MATCHING_KAFKA_PUBLISHER] matching.matched 발행 실패 - matchingId: {}", event.matchingId());
+					//TODO 아웃박스 적용 필요, 현재는 로그만 기록, 이벤트 유실 가능성 농후
+					log.error("[MATCHING_KAFKA_PUBLISHER] matching.matched 발행 실패 - matchingId: {}", event.matchingId(), ex);
 				}
 			});
 	}

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/message/MatchingEventKafkaPublisher.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/message/MatchingEventKafkaPublisher.java
@@ -2,6 +2,7 @@ package com.yeoljeong.tripmate.matching.infrastructure.message;
 
 import com.yeoljeong.tripmate.event.EventUtils;
 import com.yeoljeong.tripmate.event.MatchingCreateEvent;
+import com.yeoljeong.tripmate.event.MatchingMatchedEvent;
 import com.yeoljeong.tripmate.event.enums.MatchingTopic;
 import com.yeoljeong.tripmate.matching.application.external.MatchingEventPublisher;
 import com.yeoljeong.tripmate.matching.domain.model.Matching;
@@ -29,6 +30,29 @@ public class MatchingEventKafkaPublisher implements MatchingEventPublisher {
 					log.info("[Kafka] matching.created 발행 성공 - matchingId: {}", event.matchingId());
 				}
 			});
+	}
+
+	@Override
+	public void publishMatchingAccomplished(Matching matching) {
+		MatchingMatchedEvent event = toMatchingMatchedEvent(matching);
+		kafkaTemplate.send(MatchingTopic.MATCHING_MATCHED_TOPIC, event.matchingId().toString(), event)
+			.whenComplete((result, ex) -> {
+				if (ex != null) {
+					log.error("[MATCHING_KAFKA_PUBLISHER] matching.matched 발행 실패 - matchingId: {}", event.matchingId());
+				}
+			});
+	}
+
+	private MatchingMatchedEvent toMatchingMatchedEvent(Matching matching) {
+		try {
+			return new MatchingMatchedEvent(
+				EventUtils.getEventHash("matching", matching.getId().toString(), matching.getUpdatedAt()),
+				matching.getId(), matching.getHostUserId(), matching.getMateUserId(), matching.getTitle()
+			);
+		} catch (NoSuchAlgorithmException e) {
+			log.error("[MATCHING_KAFKA_PUBLISHER] matching.matched 이벤트 해시 생성 실패 - matching id: {}", matching.getId());
+			throw new RuntimeException(e);
+		}
 	}
 
 	private MatchingCreateEvent toMatchingCreatedEvent(Matching matching)

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/persistence/jpa/MatchingJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/persistence/jpa/MatchingJpaRepository.java
@@ -9,4 +9,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MatchingJpaRepository extends JpaRepository<Matching, UUID> {
 	boolean existsByHostUserIdAndStatus(UUID hostId, MatchingStatus status);
 	Optional<Matching> findByHostUserIdAndStatus(UUID hostId, MatchingStatus status);
+	Optional<Matching> findByIdAndIsDeletedFalse(UUID matchingId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/persistence/repositoryimpl/MatchingRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/persistence/repositoryimpl/MatchingRepositoryImpl.java
@@ -41,4 +41,9 @@ public class MatchingRepositoryImpl implements MatchingRepository {
 			mbtiIE, mbtiSN, mbtiTF, mbtiPJ
 		);
 	}
+
+	@Override
+	public Optional<Matching> findByIdAndIsDeletedFalse(UUID matchingId) {
+		return repository.findByIdAndIsDeletedFalse(matchingId);
+	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/presentation/MatchingController.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/presentation/MatchingController.java
@@ -1,6 +1,7 @@
 package com.yeoljeong.tripmate.matching.presentation;
 
 import static com.yeoljeong.tripmate.response.constants.CommonSuccessCode.CREATE;
+import static com.yeoljeong.tripmate.response.constants.CommonSuccessCode.OK;
 
 import com.yeoljeong.tripmate.auth.annotation.LoginUser;
 import com.yeoljeong.tripmate.auth.context.UserContext;
@@ -12,11 +13,14 @@ import com.yeoljeong.tripmate.matching.presentation.dto.response.MatchingDetailR
 import com.yeoljeong.tripmate.response.ApiResponse;
 import jakarta.validation.Valid;
 import java.security.NoSuchAlgorithmException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -43,12 +47,29 @@ public class MatchingController {
 		);
 	}
 
-	@GetMapping(value = "/sub", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+	@GetMapping(value = "/mate/sub", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
 	public SseEmitter subscribe(
 		@LoginUser UserContext userContext,
 		@Valid @ModelAttribute UserMatchingCriteriaRequest request
 	) {
 		return subscriptionService.
 			subscribe(request.toCommand(userContext.userId()));
+	}
+
+	@GetMapping(value = "/host/sub", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+	public SseEmitter subscribe(
+		@LoginUser UserContext userContext
+	) {
+		return subscriptionService.
+			subscribe(userContext.userId());
+	}
+
+	@PatchMapping("/{matchingId}/approval")
+	public ResponseEntity<ApiResponse<Void>> accept(
+		@LoginUser UserContext userContext,
+		@PathVariable UUID matchingId
+	) {
+		commandService.accept(userContext.userId(), matchingId);
+		return ResponseEntity.ok(ApiResponse.success(OK, null));
 	}
 }


### PR DESCRIPTION
### summary
매칭 수락 기능을 구현했습니다. 선착순 수락 방식으로 조건에 맞는 mate가 수락 시 매칭 상태가 OPEN → MATCHED로 변경되며, mateUserId가 기록됩니다. 수락 완료 시 `matching.matched` 토픽으로 Kafka 이벤트를 발행하여 알림 서버가 호스트와 메이트 양쪽에 알림을 전송할 수 있도록 했습니다.

---

### changes

**생성된 파일**
- `MatchingMatchedEvent` — 매칭 완료 이벤트 DTO (matchingId, hostUserId, mateUserId, title 포함)

**수정된 파일**
- `Matching` — `mateUserId` 필드 추가, `accept(UUID userId)` 도메인 메서드 추가
- `MatchingErrorCode` — `MATCHING_ALREADY_MATCHED`, `HOST_CANNOT_ACCEPT_OWN_MATCHING` 추가
- `MatchingEventPublisher` — `publishMatchingAccomplished(Matching matching)` 메서드 추가
- `MatchingEventKafkaPublisher` — `publishMatchingAccomplished()` 구현, `toMatchingMatchedEvent()` 추가
- `MatchingTopic` — `MATCHING_MATCHED_TOPIC = "matching.matched"` 추가
- `MatchingCommandService` — `accept(UUID userId, UUID matchingId)` 메서드 추가
- `MatchingController` — `PATCH /{matchingId}/accept` 엔드포인트 추가

---

### background
- 수락은 선착순입니다. 이미 MATCHED 상태인 매칭에 수락 요청 시 `MATCHING_ALREADY_MATCHED` 예외가 발생합니다.
- 호스트는 본인 매칭방을 수락할 수 없습니다. `HOST_CANNOT_ACCEPT_OWN_MATCHING` 예외가 발생합니다.
- `matching.matched` 토픽을 알림 서버에서 구독하고 있어야 호스트/메이트 양쪽에 알림이 전송됩니다. 알림 서버 담당자와 토픽 구독 설정을 맞춰주세요.
- 동시에 여러 명이 수락을 시도할 경우 race condition이 발생할 수 있습니다. 현재는 별도 동시성 제어가 없으므로 추후 낙관적 락 적용이 필요합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 매칭 수락 기능이 추가되었습니다. 사용자는 매칭 요청을 수락할 수 있으며, 호스트 자신의 매칭 수락 시와 이미 완성된 매칭에 대한 수락은 거부됩니다.
  * 역할별 실시간 알림 구독 엔드포인트가 추가되어 메이트와 호스트가 각각 전용 SSE 채널로 매칭 정보를 수신합니다.
  * 매칭 완성 이벤트가 발행되어 관련 알림과 연동됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->