### PR TITLE
feat: 매칭 수락 시 구독 중인 후보 유저들에게 완료된 매칭을 실시간으로 제거하는 기능을 구현

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/common/message/MatchingMatchedPayload.java
+++ b/src/main/java/com/yeoljeong/tripmate/common/message/MatchingMatchedPayload.java
@@ -1,0 +1,9 @@
+package com.yeoljeong.tripmate.common.message;
+
+import java.util.UUID;
+
+public record MatchingMatchedPayload(
+	UUID matchingId
+) {
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/MatchingNotificationService.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/MatchingNotificationService.java
@@ -34,20 +34,20 @@ public class MatchingNotificationService implements NotifyMatchingCandidatesUsec
 	}
 
 	@Override
-	public void sendMatchingAccomplished(UUID hostUserId) {
-		List<UUID> candidates = matchingCandidateStore.get(hostUserId);
+	public void sendMatchingAccomplished(UUID matchingId) {
+		List<UUID> candidates = matchingCandidateStore.get(matchingId);
 		if (candidates.isEmpty()) return;
 		List<UUID> failed = new ArrayList<>();
 		candidates.forEach(userId -> {
 			try {
-				matchingNotifier.publishClosedToUser(userId, hostUserId);
+				matchingNotifier.publishClosedToUser(userId, matchingId);
 			} catch (Exception e) {
 				log.error("[Matching] closed 이벤트 전송 실패 - userId: {}, error: {}", userId, e.getMessage(), e);
 				failed.add(userId);
 			}
 		});
 		if (failed.isEmpty()) {
-			matchingCandidateStore.delete(hostUserId);
+			matchingCandidateStore.delete(matchingId);
 		} else {
 			log.error("[Matching] 일부 candidates 전송 실패 - 실패 수: {}", failed.size());
 		}

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/MatchingNotificationService.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/MatchingNotificationService.java
@@ -9,6 +9,7 @@ import com.yeoljeong.tripmate.matching.application.external.MatchingNotifier;
 import com.yeoljeong.tripmate.matching.application.usecase.NotifyMatchingCandidatesUsecase;
 import com.yeoljeong.tripmate.matching.domain.model.Matching;
 import com.yeoljeong.tripmate.matching.domain.repository.MatchingRepository;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -34,10 +35,21 @@ public class MatchingNotificationService implements NotifyMatchingCandidatesUsec
 
 	@Override
 	public void sendMatchingAccomplished(UUID hostUserId) {
-		List<UUID> candidates = matchingCandidateStore.getAndDelete(hostUserId);
+		List<UUID> candidates = matchingCandidateStore.get(hostUserId);
 		if (candidates.isEmpty()) return;
-		candidates.forEach(userId ->
-			matchingNotifier.publishClosedToUser(userId, hostUserId)
-		);
+		List<UUID> failed = new ArrayList<>();
+		candidates.forEach(userId -> {
+			try {
+				matchingNotifier.publishClosedToUser(userId, hostUserId);
+			} catch (Exception e) {
+				log.error("[Matching] closed 이벤트 전송 실패 - userId: {}, error: {}", userId, e.getMessage(), e);
+				failed.add(userId);
+			}
+		});
+		if (failed.isEmpty()) {
+			matchingCandidateStore.delete(hostUserId);
+		} else {
+			log.error("[Matching] 일부 candidates 전송 실패 - 실패 수: {}", failed.size());
+		}
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/MatchingNotificationService.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/MatchingNotificationService.java
@@ -4,10 +4,13 @@ import static com.yeoljeong.tripmate.matching.domain.exception.MatchingErrorCode
 
 import com.yeoljeong.tripmate.exception.BusinessException;
 import com.yeoljeong.tripmate.matching.application.dto.command.NotifyMatchingCommand;
+import com.yeoljeong.tripmate.matching.application.external.MatchingCandidateStore;
 import com.yeoljeong.tripmate.matching.application.external.MatchingNotifier;
 import com.yeoljeong.tripmate.matching.application.usecase.NotifyMatchingCandidatesUsecase;
 import com.yeoljeong.tripmate.matching.domain.model.Matching;
 import com.yeoljeong.tripmate.matching.domain.repository.MatchingRepository;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -19,6 +22,7 @@ public class MatchingNotificationService implements NotifyMatchingCandidatesUsec
 
 	private final MatchingRepository repository;
 	private final MatchingNotifier matchingNotifier;
+	private final MatchingCandidateStore matchingCandidateStore;
 
 	@Override
 	public void sendMatchingInfo(NotifyMatchingCommand command) {
@@ -26,5 +30,14 @@ public class MatchingNotificationService implements NotifyMatchingCandidatesUsec
 			.orElseThrow(() -> new BusinessException(NO_ACTIVE_MATCHING));
 
 		matchingNotifier.publishToUsers(command.userIds(), matching);
+	}
+
+	@Override
+	public void sendMatchingAccomplished(UUID matchingId) {
+		List<UUID> candidates = matchingCandidateStore.getAndDelete(matchingId);
+		if (candidates.isEmpty()) return;
+		candidates.forEach(userId ->
+			matchingNotifier.publishClosedToUser(userId, matchingId)
+		);
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/MatchingNotificationService.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/MatchingNotificationService.java
@@ -33,11 +33,11 @@ public class MatchingNotificationService implements NotifyMatchingCandidatesUsec
 	}
 
 	@Override
-	public void sendMatchingAccomplished(UUID matchingId) {
-		List<UUID> candidates = matchingCandidateStore.getAndDelete(matchingId);
+	public void sendMatchingAccomplished(UUID hostUserId) {
+		List<UUID> candidates = matchingCandidateStore.getAndDelete(hostUserId);
 		if (candidates.isEmpty()) return;
 		candidates.forEach(userId ->
-			matchingNotifier.publishClosedToUser(userId, matchingId)
+			matchingNotifier.publishClosedToUser(userId, hostUserId)
 		);
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/external/MatchingCandidateStore.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/external/MatchingCandidateStore.java
@@ -5,5 +5,5 @@ import java.util.UUID;
 
 public interface MatchingCandidateStore {
 	void save(UUID userId, List<UUID> candidateIds);
-	List<UUID> getAndDelete(UUID matchingId);
+	List<UUID> getAndDelete(UUID hostUserId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/external/MatchingCandidateStore.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/external/MatchingCandidateStore.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.UUID;
 
 public interface MatchingCandidateStore {
-	void save(UUID userId, List<UUID> candidateIds);
-	List<UUID> get(UUID hostUserId);
-	void delete(UUID hostUserId);
+	void save(UUID matchingId, List<UUID> candidateIds);
+	List<UUID> get(UUID matchingId);
+	void delete(UUID matchingId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/external/MatchingCandidateStore.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/external/MatchingCandidateStore.java
@@ -5,5 +5,6 @@ import java.util.UUID;
 
 public interface MatchingCandidateStore {
 	void save(UUID userId, List<UUID> candidateIds);
-	List<UUID> getAndDelete(UUID hostUserId);
+	List<UUID> get(UUID hostUserId);
+	void delete(UUID hostUserId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/external/MatchingCandidateStore.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/external/MatchingCandidateStore.java
@@ -1,0 +1,9 @@
+package com.yeoljeong.tripmate.matching.application.external;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface MatchingCandidateStore {
+	void save(UUID userId, List<UUID> candidateIds);
+	List<UUID> getAndDelete(UUID matchingId);
+}

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/external/MatchingNotifier.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/external/MatchingNotifier.java
@@ -7,4 +7,5 @@ import java.util.UUID;
 public interface MatchingNotifier {
 	void publishToUsers(List<UUID> userIds, Matching matching);
 	void publishToUserDirect(UUID userId, Matching matching);
+	void publishClosedToUser(UUID userId, UUID matchingId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/external/MatchingNotifier.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/external/MatchingNotifier.java
@@ -7,5 +7,5 @@ import java.util.UUID;
 public interface MatchingNotifier {
 	void publishToUsers(List<UUID> userIds, Matching matching);
 	void publishToUserDirect(UUID userId, Matching matching);
-	void publishClosedToUser(UUID userId, UUID matchingId);
+	void publishClosedToUser(UUID userId, UUID hostUserId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/usecase/NotifyMatchingCandidatesUsecase.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/usecase/NotifyMatchingCandidatesUsecase.java
@@ -1,7 +1,9 @@
 package com.yeoljeong.tripmate.matching.application.usecase;
 
 import com.yeoljeong.tripmate.matching.application.dto.command.NotifyMatchingCommand;
+import java.util.UUID;
 
 public interface NotifyMatchingCandidatesUsecase {
 	void sendMatchingInfo(NotifyMatchingCommand command);
+	void sendMatchingAccomplished(UUID matchingId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/message/MatchingEventListener.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/message/MatchingEventListener.java
@@ -4,7 +4,6 @@ import com.yeoljeong.tripmate.event.MatchingCandidatesFoundEvent;
 import com.yeoljeong.tripmate.event.MatchingMatchedEvent;
 import com.yeoljeong.tripmate.event.enums.MatchingTopic;
 import com.yeoljeong.tripmate.exception.BusinessException;
-import com.yeoljeong.tripmate.matching.application.MatchingNotificationService;
 import com.yeoljeong.tripmate.matching.application.dto.command.NotifyMatchingCommand;
 import com.yeoljeong.tripmate.matching.application.external.MatchingCandidateStore;
 import com.yeoljeong.tripmate.matching.application.usecase.NotifyMatchingCandidatesUsecase;
@@ -53,7 +52,7 @@ public class MatchingEventListener {
 	)
 	public void handleMatchingMatched(@Payload MatchingMatchedEvent event, Acknowledgment acknowledgment) {
 		try {
-			notifyMatchingCandidatesUsecase.sendMatchingAccomplished(event.matchingId());
+			notifyMatchingCandidatesUsecase.sendMatchingAccomplished(event.hostUserId());
 			acknowledgment.acknowledge();
 		} catch (Exception e) {
 			log.error("[Matching] matched 처리 실패 - matchingId: {}, error: {}", event.matchingId(), e.getMessage(), e);

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/message/MatchingEventListener.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/message/MatchingEventListener.java
@@ -1,9 +1,12 @@
 package com.yeoljeong.tripmate.matching.infrastructure.message;
 
 import com.yeoljeong.tripmate.event.MatchingCandidatesFoundEvent;
+import com.yeoljeong.tripmate.event.MatchingMatchedEvent;
 import com.yeoljeong.tripmate.event.enums.MatchingTopic;
 import com.yeoljeong.tripmate.exception.BusinessException;
+import com.yeoljeong.tripmate.matching.application.MatchingNotificationService;
 import com.yeoljeong.tripmate.matching.application.dto.command.NotifyMatchingCommand;
+import com.yeoljeong.tripmate.matching.application.external.MatchingCandidateStore;
 import com.yeoljeong.tripmate.matching.application.usecase.NotifyMatchingCandidatesUsecase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +21,7 @@ import org.springframework.stereotype.Component;
 public class MatchingEventListener {
 
 	private final NotifyMatchingCandidatesUsecase notifyMatchingCandidatesUsecase;
+	private final MatchingCandidateStore matchingCandidateStore;
 
 	@KafkaListener(
 		topics = MatchingTopic.MATCHING_CANDIDATES_FOUND_TOPIC,
@@ -26,6 +30,7 @@ public class MatchingEventListener {
 	)
 	public void handleMatchingCandidatesFound(@Payload MatchingCandidatesFoundEvent event, Acknowledgment acknowledgment) {
 		try {
+			matchingCandidateStore.save(event.hostUserId(), event.userIds());
 			notifyMatchingCandidatesUsecase.sendMatchingInfo(
 				new NotifyMatchingCommand(event.hostUserId(), event.userIds())
 			);
@@ -41,4 +46,18 @@ public class MatchingEventListener {
 		}
 	}
 
+	@KafkaListener(
+		topics = MatchingTopic.MATCHING_MATCHED_TOPIC,
+		groupId = "${spring.kafka.consumer.group-id}",
+		containerFactory = "kafkaListenerContainerFactory"
+	)
+	public void handleMatchingMatched(@Payload MatchingMatchedEvent event, Acknowledgment acknowledgment) {
+		try {
+			notifyMatchingCandidatesUsecase.sendMatchingAccomplished(event.matchingId());
+			acknowledgment.acknowledge();
+		} catch (Exception e) {
+			log.error("[Matching] matched 처리 실패 - matchingId: {}, error: {}", event.matchingId(), e.getMessage(), e);
+			throw e;
+		}
+	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/message/MatchingEventListener.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/message/MatchingEventListener.java
@@ -29,7 +29,7 @@ public class MatchingEventListener {
 	)
 	public void handleMatchingCandidatesFound(@Payload MatchingCandidatesFoundEvent event, Acknowledgment acknowledgment) {
 		try {
-			matchingCandidateStore.save(event.hostUserId(), event.userIds());
+			matchingCandidateStore.save(event.matchingId(), event.userIds());
 			notifyMatchingCandidatesUsecase.sendMatchingInfo(
 				new NotifyMatchingCommand(event.hostUserId(), event.userIds())
 			);
@@ -52,7 +52,7 @@ public class MatchingEventListener {
 	)
 	public void handleMatchingMatched(@Payload MatchingMatchedEvent event, Acknowledgment acknowledgment) {
 		try {
-			notifyMatchingCandidatesUsecase.sendMatchingAccomplished(event.hostUserId());
+			notifyMatchingCandidatesUsecase.sendMatchingAccomplished(event.matchingId());
 			acknowledgment.acknowledge();
 		} catch (Exception e) {
 			log.error("[Matching] matched 처리 실패 - matchingId: {}, error: {}", event.matchingId(), e.getMessage(), e);

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/message/MatchingSseRedisPublisher.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/message/MatchingSseRedisPublisher.java
@@ -1,5 +1,6 @@
 package com.yeoljeong.tripmate.matching.infrastructure.message;
 
+import com.yeoljeong.tripmate.common.message.MatchingMatchedPayload;
 import com.yeoljeong.tripmate.common.message.MatchingSsePayload;
 import com.yeoljeong.tripmate.matching.application.external.MatchingNotifier;
 import com.yeoljeong.tripmate.matching.domain.model.Matching;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Component;
 public class MatchingSseRedisPublisher implements MatchingNotifier {
 
 	private final static String CHANNEL_PREFIX = "matching:sse:";
+	private final static String CLOSED_CHANNEL_PREFIX = "matching:sse:closed:";
 	private static final String GUARD_KEY_PREFIX = "sse:sent:";
 
 	private final RedisTemplate<String, Object> redisTemplate;
@@ -29,6 +31,17 @@ public class MatchingSseRedisPublisher implements MatchingNotifier {
 	@Override
 	public void publishToUserDirect(UUID userId, Matching matching) {
 		publish(userId, matching);
+	}
+
+	@Override
+	public void publishClosedToUser(UUID userId, UUID matchingId) {
+		String channel = CLOSED_CHANNEL_PREFIX + userId;
+		try {
+			redisTemplate.convertAndSend(channel, new MatchingMatchedPayload(matchingId));
+			log.debug("[MatchingSSE] 매칭 종료 전송 - userId: {}, matchingId: {}", userId, matchingId);
+		} catch (Exception e) {
+			log.error("[MatchingSSE] 매칭 종료 전송 실패 - channel: {}, error : {}]", channel, e.getMessage(), e);
+		}
 	}
 
 	private void publishWithGuard(UUID userId, Matching matching) {

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/message/MatchingSseRedisPublisher.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/message/MatchingSseRedisPublisher.java
@@ -41,6 +41,7 @@ public class MatchingSseRedisPublisher implements MatchingNotifier {
 			log.debug("[MatchingSSE] 매칭 종료 전송 - userId: {}, hostUserId: {}", userId, hostUserId);
 		} catch (Exception e) {
 			log.error("[MatchingSSE] 매칭 종료 전송 실패 - channel: {}, error : {}]", channel, e.getMessage(), e);
+			throw e;
 		}
 	}
 

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/message/MatchingSseRedisPublisher.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/message/MatchingSseRedisPublisher.java
@@ -34,11 +34,11 @@ public class MatchingSseRedisPublisher implements MatchingNotifier {
 	}
 
 	@Override
-	public void publishClosedToUser(UUID userId, UUID matchingId) {
+	public void publishClosedToUser(UUID userId, UUID hostUserId) {
 		String channel = CLOSED_CHANNEL_PREFIX + userId;
 		try {
-			redisTemplate.convertAndSend(channel, new MatchingMatchedPayload(matchingId));
-			log.debug("[MatchingSSE] 매칭 종료 전송 - userId: {}, matchingId: {}", userId, matchingId);
+			redisTemplate.convertAndSend(channel, new MatchingMatchedPayload(hostUserId));
+			log.debug("[MatchingSSE] 매칭 종료 전송 - userId: {}, hostUserId: {}", userId, hostUserId);
 		} catch (Exception e) {
 			log.error("[MatchingSSE] 매칭 종료 전송 실패 - channel: {}, error : {}]", channel, e.getMessage(), e);
 		}

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/redis/MatchingCandidateRedisStore.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/redis/MatchingCandidateRedisStore.java
@@ -31,11 +31,19 @@ public class MatchingCandidateRedisStore implements MatchingCandidateStore {
 					LocalDateTime.now(),
 					matching.getMatchingPeriod().getRecruitDeadline()
 				);
+				if (ttl.isNegative() || ttl.isZero()) {
+					log.warn("[Redis] recruitDeadline이 이미 지남 - matchingId: {}", matching.getId());
+					return;
+				}
 				candidateIds.forEach(userId ->
 					redisTemplate.opsForSet().add(key, userId.toString())
 				);
+				String[] candidateIdsStr = candidateIds.stream()
+					.map(UUID::toString)
+					.toArray(String[]::new);
+				redisTemplate.opsForSet().add(key, candidateIdsStr);
 				redisTemplate.expire(key, ttl);
-				log.debug("[Redis] candidats 저장 - matchingId: {}, 후보수: {}",
+				log.debug("[Redis] candidates 저장 - matchingId: {}, 후보수: {}",
 					matching.getId(), candidateIds.size());
 			});
 	}

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/redis/MatchingCandidateRedisStore.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/redis/MatchingCandidateRedisStore.java
@@ -23,9 +23,9 @@ public class MatchingCandidateRedisStore implements MatchingCandidateStore {
 	private final MatchingRepository repository;
 
 	@Override
-	public void save(UUID hostUserId, List<UUID> candidateIds) {
-		String key = MATCHING_CANDIDATE_KEY_PREFIX + hostUserId;
-		repository.findByHostUserIdAndMatchingStatusOpen(hostUserId)
+	public void save(UUID matchingId, List<UUID> candidateIds) {
+		String key = MATCHING_CANDIDATE_KEY_PREFIX + matchingId;
+		repository.findByHostUserIdAndMatchingStatusOpen(matchingId)
 			.ifPresent(matching -> {
 				Duration ttl = Duration.between(
 					LocalDateTime.now(),
@@ -46,8 +46,8 @@ public class MatchingCandidateRedisStore implements MatchingCandidateStore {
 	}
 
 	@Override
-	public List<UUID> get(UUID hostUserId) {
-		String key = MATCHING_CANDIDATE_KEY_PREFIX + hostUserId;
+	public List<UUID> get(UUID matchingId) {
+		String key = MATCHING_CANDIDATE_KEY_PREFIX + matchingId;
 		Set<Object> members = redisTemplate.opsForSet().members(key);
 		if (members == null) return List.of();
 		return members.stream()
@@ -56,7 +56,7 @@ public class MatchingCandidateRedisStore implements MatchingCandidateStore {
 	}
 
 	@Override
-	public void delete(UUID hostUserId) {
-		redisTemplate.delete(MATCHING_CANDIDATE_KEY_PREFIX + hostUserId);
+	public void delete(UUID matchingId) {
+		redisTemplate.delete(MATCHING_CANDIDATE_KEY_PREFIX + matchingId);
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/redis/MatchingCandidateRedisStore.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/redis/MatchingCandidateRedisStore.java
@@ -1,0 +1,54 @@
+package com.yeoljeong.tripmate.matching.infrastructure.redis;
+
+import com.yeoljeong.tripmate.matching.application.external.MatchingCandidateStore;
+import com.yeoljeong.tripmate.matching.domain.repository.MatchingRepository;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class MatchingCandidateRedisStore implements MatchingCandidateStore {
+
+	private final static String MATCHING_CANDIDATE_KEY_PREFIX = "matching:candidate:";
+
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final MatchingRepository repository;
+
+	@Override
+	public void save(UUID hostUserId, List<UUID> candidateIds) {
+		repository.findByHostUserIdAndMatchingStatusOpen(hostUserId)
+			.ifPresent(matching -> {
+				String key = MATCHING_CANDIDATE_KEY_PREFIX + matching.getId();
+				Duration ttl = Duration.between(
+					LocalDateTime.now(),
+					matching.getMatchingPeriod().getRecruitDeadline()
+				);
+				candidateIds.forEach(userId ->
+					redisTemplate.opsForSet().add(key, userId.toString())
+				);
+				redisTemplate.expire(key, ttl);
+				log.debug("[Redis] candidats 저장 - matchingId: {}, 후보수: {}", matching.getId(), candidateIds.size());
+			});
+	}
+
+	@Override
+	public List<UUID> getAndDelete(UUID matchingId) {
+		String key = MATCHING_CANDIDATE_KEY_PREFIX + matchingId;
+		Set<Object> members = redisTemplate.opsForSet().members(key);
+		redisTemplate.delete(key);
+
+		if (members == null) return List.of();
+
+		return members.stream()
+			.map(id -> UUID.fromString(id.toString()))
+			.toList();
+	}
+}

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/redis/MatchingCandidateRedisStore.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/redis/MatchingCandidateRedisStore.java
@@ -35,9 +35,6 @@ public class MatchingCandidateRedisStore implements MatchingCandidateStore {
 					log.warn("[Redis] recruitDeadline이 이미 지남 - matchingId: {}", matching.getId());
 					return;
 				}
-				candidateIds.forEach(userId ->
-					redisTemplate.opsForSet().add(key, userId.toString())
-				);
 				String[] candidateIdsStr = candidateIds.stream()
 					.map(UUID::toString)
 					.toArray(String[]::new);

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/redis/MatchingCandidateRedisStore.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/redis/MatchingCandidateRedisStore.java
@@ -49,15 +49,17 @@ public class MatchingCandidateRedisStore implements MatchingCandidateStore {
 	}
 
 	@Override
-	public List<UUID> getAndDelete(UUID hostUserId) {
+	public List<UUID> get(UUID hostUserId) {
 		String key = MATCHING_CANDIDATE_KEY_PREFIX + hostUserId;
 		Set<Object> members = redisTemplate.opsForSet().members(key);
-		redisTemplate.delete(key);
-
 		if (members == null) return List.of();
-
 		return members.stream()
 			.map(id -> UUID.fromString(id.toString()))
 			.toList();
+	}
+
+	@Override
+	public void delete(UUID hostUserId) {
+		redisTemplate.delete(MATCHING_CANDIDATE_KEY_PREFIX + hostUserId);
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/redis/MatchingCandidateRedisStore.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/redis/MatchingCandidateRedisStore.java
@@ -24,9 +24,9 @@ public class MatchingCandidateRedisStore implements MatchingCandidateStore {
 
 	@Override
 	public void save(UUID hostUserId, List<UUID> candidateIds) {
+		String key = MATCHING_CANDIDATE_KEY_PREFIX + hostUserId;
 		repository.findByHostUserIdAndMatchingStatusOpen(hostUserId)
 			.ifPresent(matching -> {
-				String key = MATCHING_CANDIDATE_KEY_PREFIX + matching.getId();
 				Duration ttl = Duration.between(
 					LocalDateTime.now(),
 					matching.getMatchingPeriod().getRecruitDeadline()
@@ -35,13 +35,14 @@ public class MatchingCandidateRedisStore implements MatchingCandidateStore {
 					redisTemplate.opsForSet().add(key, userId.toString())
 				);
 				redisTemplate.expire(key, ttl);
-				log.debug("[Redis] candidats 저장 - matchingId: {}, 후보수: {}", matching.getId(), candidateIds.size());
+				log.debug("[Redis] candidats 저장 - matchingId: {}, 후보수: {}",
+					matching.getId(), candidateIds.size());
 			});
 	}
 
 	@Override
-	public List<UUID> getAndDelete(UUID matchingId) {
-		String key = MATCHING_CANDIDATE_KEY_PREFIX + matchingId;
+	public List<UUID> getAndDelete(UUID hostUserId) {
+		String key = MATCHING_CANDIDATE_KEY_PREFIX + hostUserId;
 		Set<Object> members = redisTemplate.opsForSet().members(key);
 		redisTemplate.delete(key);
 

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/sse/MatchingRedisSseManager.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/sse/MatchingRedisSseManager.java
@@ -1,6 +1,7 @@
 package com.yeoljeong.tripmate.matching.infrastructure.sse;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yeoljeong.tripmate.common.message.MatchingMatchedPayload;
 import com.yeoljeong.tripmate.common.message.MatchingSsePayload;
 import com.yeoljeong.tripmate.matching.application.external.MatchingSseManager;
 import java.io.IOException;
@@ -21,10 +22,13 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class MatchingRedisSseManager implements MatchingSseManager {
 
 	private final static String CHANNEL_PREFIX = "matching:sse:";
+	private final static String CLOSED_CHANNEL_PREFIX = "matching:sse:closed:";
+
 	private final static long TIMEOUT = 10 * 60 * 1000L;
 
 	private final Map<UUID, SseEmitter> emitters = new ConcurrentHashMap<>();
 	private final Map<UUID, MessageListener> listeners = new ConcurrentHashMap<>();
+	private final Map<UUID, MessageListener> closedListeners = new ConcurrentHashMap<>();
 
 	private final RedisMessageListenerContainer listenerContainer;
 	private final ObjectMapper objectMapper;
@@ -35,7 +39,8 @@ public class MatchingRedisSseManager implements MatchingSseManager {
 		SseEmitter emitter = new SseEmitter(TIMEOUT);
 		emitters.put(userId, emitter);
 
-		registerRedisListener(userId, emitter);
+		registerMatchingListener(userId, emitter);
+		registerCloseListener(userId, emitter);
 		sendConnectEvent(userId, emitter);
 
 		emitter.onCompletion(() -> cleanup(userId));
@@ -50,7 +55,7 @@ public class MatchingRedisSseManager implements MatchingSseManager {
 		cleanup(userId);
 	}
 
-	private void registerRedisListener(UUID userId, SseEmitter emitter) {
+	private void registerMatchingListener(UUID userId, SseEmitter emitter) {
 		ChannelTopic topic = new ChannelTopic(CHANNEL_PREFIX + userId);
 		MessageListener listener = (message, pattern) -> {
 			try {
@@ -73,6 +78,30 @@ public class MatchingRedisSseManager implements MatchingSseManager {
 		listenerContainer.addMessageListener(listener, topic);
 	}
 
+	private void registerCloseListener(UUID userId, SseEmitter emitter) {
+		ChannelTopic topic = new ChannelTopic(CLOSED_CHANNEL_PREFIX + userId);
+
+		MessageListener listener = (message, pattern) -> {
+			try {
+				MatchingMatchedPayload payload = objectMapper.readValue(
+					message.getBody(), MatchingMatchedPayload.class
+				);
+				emitter.send(
+					SseEmitter.event()
+						.name("matching-closed")
+						.data(payload)
+				);
+			} catch (IOException e) {
+				log.error("[MatchingSSE] closed 이벤트 전송 실패 - userId: {}", userId);
+				cleanup(userId);
+				emitter.completeWithError(e);
+			}
+		};
+
+		closedListeners.put(userId, listener);
+		listenerContainer.addMessageListener(listener, topic);
+	}
+
 	private void cleanup(UUID userId) {
 		SseEmitter emitter = emitters.remove(userId);
 		if (emitter != null) {
@@ -83,6 +112,13 @@ public class MatchingRedisSseManager implements MatchingSseManager {
 			listenerContainer.removeMessageListener(
 				listener,
 				new ChannelTopic(CHANNEL_PREFIX + userId)
+			);
+		}
+		MessageListener closedListener = closedListeners.remove(userId);
+		if (closedListener != null) {
+			listenerContainer.removeMessageListener(
+				closedListener,
+				new ChannelTopic(CLOSED_CHANNEL_PREFIX + userId)
 			);
 		}
 	}

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/application/UserSettingQueryService.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/application/UserSettingQueryService.java
@@ -42,6 +42,6 @@ public class UserSettingQueryService implements FindEnableMatchingUserUsecase {
 			.filter(userId -> !userId.equals(criteria.hostUserId()))
 			.toList();
 		log.info("[UserSetting] 후보 유저 수: {}", candidates.size()); // 추가
-		publisher.publishMatchingCandidates(criteria.hostUserId(), candidates);
+		publisher.publishMatchingCandidates(criteria.matchingId(), criteria.hostUserId(), candidates);
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/application/dto/command/MatchingCandidateCriteria.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/application/dto/command/MatchingCandidateCriteria.java
@@ -3,6 +3,7 @@ package com.yeoljeong.tripmate.usersetting.application.dto.command;
 import java.util.UUID;
 
 public record MatchingCandidateCriteria(
+	UUID matchingId,
 	UUID hostUserId,
 	boolean allowSmoking,
 	String preferenceMbtiIE,

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/application/external/UserSettingEventPublisher.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/application/external/UserSettingEventPublisher.java
@@ -5,6 +5,6 @@ import java.util.List;
 import java.util.UUID;
 
 public interface UserSettingEventPublisher {
-	void publishMatchingCandidates(UUID hostUserId, List<UUID> candidates)
+	void publishMatchingCandidates(UUID matchingId, UUID hostUserId, List<UUID> candidates)
 		throws NoSuchAlgorithmException;
 }

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/message/UserSettingEventKafkaPublisher.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/message/UserSettingEventKafkaPublisher.java
@@ -22,11 +22,11 @@ public class UserSettingEventKafkaPublisher implements UserSettingEventPublisher
 	private final KafkaTemplate<String, Object> kafkaTemplate;
 
 	@Override
-	public void publishMatchingCandidates(UUID hostUserId, List<UUID> candidates)
+	public void publishMatchingCandidates(UUID matchingId, UUID hostUserId, List<UUID> candidates)
 		throws NoSuchAlgorithmException {
 		log.info("[Kafka] matching.candidates.found 발행 - hostUserId: {}, 후보수: {}",
 			hostUserId, candidates.size()); // 추가
-		MatchingCandidatesFoundEvent event = toMatchingCandidatesFoundEvent(hostUserId, candidates);
+		MatchingCandidatesFoundEvent event = toMatchingCandidatesFoundEvent(matchingId, hostUserId, candidates);
 		kafkaTemplate.send(MATCHING_CANDIDATES_FOUND_TOPIC, event.hostUserId().toString(), event)
 			.whenComplete((result, ex) -> {
 				if (ex != null) {
@@ -38,11 +38,11 @@ public class UserSettingEventKafkaPublisher implements UserSettingEventPublisher
 			});
 	}
 
-	private MatchingCandidatesFoundEvent toMatchingCandidatesFoundEvent(UUID hostUserId, List<UUID> candidates)
+	private MatchingCandidatesFoundEvent toMatchingCandidatesFoundEvent(UUID matchingId, UUID hostUserId, List<UUID> candidates)
 		throws NoSuchAlgorithmException {
 		return new MatchingCandidatesFoundEvent(
 			EventUtils.getEventHash("matching", String.valueOf(hostUserId), LocalDateTime.now()),
-			hostUserId, candidates
+			matchingId, hostUserId, candidates
 		);
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/message/UserSettingEventListener.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/message/UserSettingEventListener.java
@@ -62,6 +62,7 @@ public class UserSettingEventListener {
 		try {
 			findEnableMatchingUserUsecase.findAllEnableMatchingUser(
 				new MatchingCandidateCriteria(
+					event.matchingId(),
 					event.hostUserId(),
 					event.allowSmoking(),
 					event.preferenceMbtiIE(),

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/message/UserSettingEventListener.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/message/UserSettingEventListener.java
@@ -29,7 +29,7 @@ public class UserSettingEventListener {
 
 	@KafkaListener(
 		topics = UserTopic.USER_CREATED_TOPIC,
-		groupId = "${spring.kafka.consumer.group-id}",
+		groupId = "matching-usersetting-group",
 		containerFactory = "kafkaListenerContainerFactory"
 	)
 	public void create(@Payload UserCreatedEvent event, Acknowledgment acknowledgment) {


### PR DESCRIPTION
### summary
매칭 수락 시 구독 중인 후보 유저들에게 완료된 매칭을 실시간으로 제거하는 기능을 구현했습니다. 후보 유저 목록을 Redis Set에 저장해두고, 수락 시 해당 목록을 조회해 `matching-closed` SSE 이벤트를 전송합니다. 또한 매칭 완료 시 호스트와 메이트의 `matchingEnabled`를 자동으로 비활성화합니다. SSE 채널을 매칭 정보용과 매칭 종료용으로 분리하여 타입 구분 없이 명확하게 처리할 수 있도록 했습니다.

---

### changes

**생성된 파일**
- `MatchingCandidateStore` — 후보 유저 목록 저장/조회 인터페이스
- `MatchingCandidateRedisStore` — Redis Set 기반 후보 유저 목록 관리 구현체
- `MatchingClosedPayload` — 매칭 종료 SSE 이벤트 DTO
- `DeactivateMatchingUsecase` — 매칭 완료 시 matchingEnabled 비활성화 유스케이스 인터페이스

**수정된 파일**
- `MatchingEventListener` — `matching.candidates.found` 수신 시 Redis Set 저장 추가, `matching.matched` 수신 시 `notifyMatchingClosed` 호출 추가
- `MatchingNotificationService` — `notifyMatchingClosed()` 추가 (Redis Set 조회 → SSE 삭제 이벤트 전송)
- `MatchingCandidateNotifier` — `publishClosedToUser()` 메서드 추가
- `MatchingSseRedisPublisher` — `publishClosedToUser()` 구현, `matching:sse:closed:{userId}` 채널 분리
- `MatchingRedisSseManager` — `matching-closed` 채널 리스너 분리 (`registerClosedListener` 추가), `cleanup()` 에 closedListener 제거 추가
- `MatchingCommandService` — `notifyMatchingClosed` 직접 호출 제거 (이벤트 리스너로 이동)
- `UserSettingCommandService` — `deactivate(hostUserId, mateUserId)` 추가
- `UserSettingEventListener` — `matching.matched` 수신 후 양쪽 `matchingEnabled = false` 처리 추가

---

### background
- SSE 채널이 두 개로 분리되었습니다.
  - `matching:sse:{userId}` — 신규 매칭 정보
  - `matching:sse:closed:{userId}` — 매칭 종료 알림
- 후보 유저 목록은 `matching:candidates:{matchingId}` Redis Set으로 관리되며 TTL은 `recruitDeadline` 기준입니다. TTL 만료 시 자동 삭제됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 매칭 완료 시 해당 매칭의 모든 후보자에게 자동으로 "매칭 종료" 실시간 알림 전송
  * 닫힘 전용 실시간 스트림 추가로 사용자에게 즉시 "matching-closed" 이벤트 제공

* **리팩토링**
  * 후보자 목록을 Redis에 보관/조회해 알림 전달 신뢰성 향상 — 전달 성공 시 목록 삭제, 부분 실패 시 보존하여 재시도 가능하도록 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->