### PR TITLE
fix: HikariCP 커넥션 풀 사이즈 조정

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,9 +1,15 @@
 spring:
+  application:
+    name: matching-service
   datasource:
     driver-class-name: org.postgresql.Driver
     url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
     username: ${POSTGRES_USER}
     password: ${POSTGRES_PASSWORD}
+    hikari:
+      maximum-pool-size: 5
+      minimum-idle: 2
+      connection-timeout: 3000
   data:
     redis:
       host: ${REDIS_HOST}


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- HikariCP 커넥션 풀 사이즈 조정

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직

#### 변경 사항
  - 각 서비스 application-prod.yml에 HikariCP 설정 추가

#### 수정 내용
maximum-pool-size: 5로 조정
10개 서비스 × 5 = 50 커넥션 → 여유 있게 운영 가능

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.

#### 원인
HikariCP 기본값(10)으로 서비스 10개가 동시 실행 시
최대 100개 커넥션 사용 → RDS max_connections(112) 한계치 도달
