### PR TITLE
feat: SSE 구독/해제 시 matchingEnabled 자동 변경 (Kafka + Outbox 패턴)

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/common/message/MateConnectEvent.java
+++ b/src/main/java/com/yeoljeong/tripmate/common/message/MateConnectEvent.java
@@ -1,0 +1,10 @@
+package com.yeoljeong.tripmate.common.message;
+
+import java.util.UUID;
+
+public class MateConnectEvent {
+
+	public record Subscribe(UUID userId) {}
+	public record Unsubscribe(UUID userId) {}
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/SubscriptionUsecaseAdapter.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/SubscriptionUsecaseAdapter.java
@@ -1,0 +1,30 @@
+package com.yeoljeong.tripmate.matching.application;
+
+import com.yeoljeong.tripmate.matching.application.dto.command.UserMatchingCriteriaCommand;
+import com.yeoljeong.tripmate.matching.application.external.MatchingEventPort;
+import com.yeoljeong.tripmate.matching.application.usecase.SubscriptionUsecase;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class SubscriptionUsecaseAdapter implements SubscriptionUsecase {
+
+	private final SseSubscriptionService sseSubscriptionService;
+	private final MatchingEventPort eventPort;
+
+	@Override
+	public SseEmitter execute(UserMatchingCriteriaCommand command) {
+		eventPort.appendMateSubscribed(command.userId());
+		return sseSubscriptionService.subscribe(command);
+	}
+
+	@Override
+	public SseEmitter execute(UUID userId) {
+		return sseSubscriptionService.subscribe(userId);
+	}
+}

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/external/MatchingEventPort.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/external/MatchingEventPort.java
@@ -1,8 +1,11 @@
 package com.yeoljeong.tripmate.matching.application.external;
 
 import com.yeoljeong.tripmate.matching.domain.model.Matching;
+import java.util.UUID;
 
 public interface MatchingEventPort {
 	void appendMatchingCreated(Matching matching);
 	void appendMatchingAccomplished(Matching matching);
+	void appendMateSubscribed(UUID userId);
+	void appendMateUnsubscribed(UUID userId);
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/usecase/SubscriptionUsecase.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/usecase/SubscriptionUsecase.java
@@ -1,0 +1,12 @@
+package com.yeoljeong.tripmate.matching.application.usecase;
+
+import com.yeoljeong.tripmate.matching.application.dto.command.UserMatchingCriteriaCommand;
+import java.util.UUID;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+public interface SubscriptionUsecase {
+
+	SseEmitter execute(UserMatchingCriteriaCommand command);
+	SseEmitter execute(UUID userId);
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/message/MatchingEventPortAdapter.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/message/MatchingEventPortAdapter.java
@@ -2,6 +2,9 @@ package com.yeoljeong.tripmate.matching.infrastructure.message;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yeoljeong.tripmate.common.message.MateConnectEvent;
+import com.yeoljeong.tripmate.common.message.MateConnectEvent.Subscribe;
+import com.yeoljeong.tripmate.common.message.MateConnectEvent.Unsubscribe;
 import com.yeoljeong.tripmate.event.EventUtils;
 import com.yeoljeong.tripmate.event.MatchingCreateEvent;
 import com.yeoljeong.tripmate.event.MatchingMatchedEvent;
@@ -11,13 +14,16 @@ import com.yeoljeong.tripmate.matching.domain.model.Matching;
 import com.yeoljeong.tripmate.matching.infrastructure.persistence.MatchingOutbox;
 import com.yeoljeong.tripmate.matching.infrastructure.persistence.jpa.MatchingOutboxRepository;
 import java.security.NoSuchAlgorithmException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @Slf4j
 @RequiredArgsConstructor
+@Transactional
 public class MatchingEventPortAdapter implements MatchingEventPort {
 
 	private final ObjectMapper objectMapper;
@@ -43,6 +49,36 @@ public class MatchingEventPortAdapter implements MatchingEventPort {
 			matchingOutboxRepository.save(MatchingOutbox.create(MatchingTopic.MATCHING_MATCHED_TOPIC, payload));
 		} catch (JsonProcessingException e) {
 			log.error("[OUTBOX] matching.matched 저장 실패 : matchingId = {}", matching.getId(), e);
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public void appendMateSubscribed(UUID userId) {
+		try {
+			MateConnectEvent.Subscribe event = new Subscribe(userId);
+			String payload = objectMapper.writeValueAsString(event);
+			matchingOutboxRepository.save(MatchingOutbox.create(
+				//TODO mate.subscribe MatchingTopic에 추가
+				"mate.subscribed",
+				payload));
+		} catch (JsonProcessingException e) {
+			log.error("[OUTBOX] mate.subscribe 저장 실패 : userId = {}", userId, e);
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public void appendMateUnsubscribed(UUID userId) {
+		try {
+			MateConnectEvent.Unsubscribe event = new Unsubscribe(userId);
+			String payload = objectMapper.writeValueAsString(event);
+			matchingOutboxRepository.save(MatchingOutbox.create(
+				//TODO mate.unsubscribe MatchingTopic에 추가
+				"mate.unsubscribed",
+				payload));
+		} catch (JsonProcessingException e) {
+			log.error("[OUTBOX] mate.unsubscribe 저장 실패 : userId = {}", userId, e);
 			throw new RuntimeException(e);
 		}
 	}

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/sse/MatchingRedisSseManager.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/sse/MatchingRedisSseManager.java
@@ -3,6 +3,7 @@ package com.yeoljeong.tripmate.matching.infrastructure.sse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yeoljeong.tripmate.common.message.MatchingMatchedPayload;
 import com.yeoljeong.tripmate.common.message.MatchingSsePayload;
+import com.yeoljeong.tripmate.matching.application.external.MatchingEventPort;
 import com.yeoljeong.tripmate.matching.application.external.MatchingSseManager;
 import java.io.IOException;
 import java.util.Map;
@@ -33,6 +34,8 @@ public class MatchingRedisSseManager implements MatchingSseManager {
 	private final RedisMessageListenerContainer listenerContainer;
 	private final ObjectMapper objectMapper;
 
+	private final MatchingEventPort eventPort;
+
 	@Override
 	public SseEmitter subscribe(UUID userId) {
 		disconnect(userId);
@@ -43,9 +46,18 @@ public class MatchingRedisSseManager implements MatchingSseManager {
 		registerCloseListener(userId, emitter);
 		sendConnectEvent(userId, emitter);
 
-		emitter.onCompletion(() -> cleanup(userId));
-		emitter.onTimeout(() -> cleanup(userId));
-		emitter.onError(e -> cleanup(userId));
+		emitter.onCompletion(() -> {
+			cleanup(userId);
+			eventPort.appendMateUnsubscribed(userId);
+		});
+		emitter.onTimeout(() -> {
+			cleanup(userId);
+			eventPort.appendMateUnsubscribed(userId);
+		});
+		emitter.onError(e -> {
+			cleanup(userId);
+			eventPort.appendMateUnsubscribed(userId);
+		});
 
 		return emitter;
 	}

--- a/src/main/java/com/yeoljeong/tripmate/matching/presentation/MatchingController.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/presentation/MatchingController.java
@@ -6,7 +6,7 @@ import static com.yeoljeong.tripmate.response.constants.CommonSuccessCode.OK;
 import com.yeoljeong.tripmate.auth.annotation.LoginUser;
 import com.yeoljeong.tripmate.auth.context.UserContext;
 import com.yeoljeong.tripmate.matching.application.MatchingCommandService;
-import com.yeoljeong.tripmate.matching.application.SseSubscriptionService;
+import com.yeoljeong.tripmate.matching.application.usecase.SubscriptionUsecase;
 import com.yeoljeong.tripmate.matching.presentation.dto.request.CreateMatchingRequest;
 import com.yeoljeong.tripmate.matching.presentation.dto.request.UserMatchingCriteriaRequest;
 import com.yeoljeong.tripmate.matching.presentation.dto.response.MatchingDetailResponse;
@@ -32,7 +32,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class MatchingController {
 
 	private final MatchingCommandService commandService;
-	private final SseSubscriptionService subscriptionService;
+	private final SubscriptionUsecase subscriptionUsecase;
 
 	@PostMapping
 	public ResponseEntity<ApiResponse<MatchingDetailResponse>> create(
@@ -51,16 +51,16 @@ public class MatchingController {
 		@LoginUser UserContext userContext,
 		@Valid @ModelAttribute UserMatchingCriteriaRequest request
 	) {
-		return subscriptionService.
-			subscribe(request.toCommand(userContext.userId()));
+		return subscriptionUsecase.
+			execute(request.toCommand(userContext.userId()));
 	}
 
 	@GetMapping(value = "/host/sub", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
 	public SseEmitter subscribe(
 		@LoginUser UserContext userContext
 	) {
-		return subscriptionService.
-			subscribe(userContext.userId());
+		return subscriptionUsecase.
+			execute(userContext.userId());
 	}
 
 	@PatchMapping("/{matchingId}/approval")

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/application/UserSettingCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/application/UserSettingCommandService.java
@@ -8,6 +8,7 @@ import com.yeoljeong.tripmate.usersetting.application.dto.command.CreateUserSett
 import com.yeoljeong.tripmate.usersetting.application.dto.command.UserSettingCommand;
 import com.yeoljeong.tripmate.usersetting.application.dto.result.UserSettingResult;
 import com.yeoljeong.tripmate.usersetting.application.usecase.CreateUserSettingUsecase;
+import com.yeoljeong.tripmate.usersetting.application.usecase.EnabledMatchingSettingUsecase;
 import com.yeoljeong.tripmate.usersetting.domain.model.UserSetting;
 import com.yeoljeong.tripmate.usersetting.domain.repository.UserSettingRepository;
 import java.util.UUID;
@@ -21,7 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 @Transactional
-public class UserSettingCommandService implements CreateUserSettingUsecase {
+public class UserSettingCommandService implements CreateUserSettingUsecase,
+	EnabledMatchingSettingUsecase {
 
 	private final UserSettingRepository userSettingRepository;
 
@@ -47,12 +49,14 @@ public class UserSettingCommandService implements CreateUserSettingUsecase {
 		}
 	}
 
+	@Override
 	public void activateMatching(UUID userId) {
 		UserSetting setting = userSettingRepository.findByUserIdAndIsDeletedFalse(userId)
 			.orElseThrow(() -> new BusinessException(NOT_FOUND_USER_SETTING));
 		setting.activateMatching();
 	}
 
+	@Override
 	public void deactivateMatching(UUID userId) {
 		UserSetting setting = userSettingRepository.findByUserIdAndIsDeletedFalse(userId)
 			.orElseThrow(() -> new BusinessException(NOT_FOUND_USER_SETTING));

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/application/usecase/EnabledMatchingSettingUsecase.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/application/usecase/EnabledMatchingSettingUsecase.java
@@ -1,0 +1,8 @@
+package com.yeoljeong.tripmate.usersetting.application.usecase;
+
+import java.util.UUID;
+
+public interface EnabledMatchingSettingUsecase {
+	void activateMatching(UUID userId);
+	void deactivateMatching(UUID userId);
+}

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/message/UserSettingEventListener.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/message/UserSettingEventListener.java
@@ -1,6 +1,7 @@
 package com.yeoljeong.tripmate.usersetting.infrastructure.message;
 
 import com.yeoljeong.tripmate.common.infrastructure.KafkaPayloadDeserializer;
+import com.yeoljeong.tripmate.common.message.MateConnectEvent;
 import com.yeoljeong.tripmate.event.MatchingCreateEvent;
 import com.yeoljeong.tripmate.event.UserCreatedEvent;
 import com.yeoljeong.tripmate.event.enums.MatchingTopic;
@@ -9,6 +10,7 @@ import com.yeoljeong.tripmate.exception.BusinessException;
 import com.yeoljeong.tripmate.usersetting.application.dto.command.CreateUserSettingCommand;
 import com.yeoljeong.tripmate.usersetting.application.dto.command.MatchingCandidateCriteria;
 import com.yeoljeong.tripmate.usersetting.application.usecase.CreateUserSettingUsecase;
+import com.yeoljeong.tripmate.usersetting.application.usecase.EnabledMatchingSettingUsecase;
 import com.yeoljeong.tripmate.usersetting.application.usecase.FindEnableMatchingUserUsecase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,7 +24,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class UserSettingEventListener {
 
-	private final CreateUserSettingUsecase usecase;
+	private final CreateUserSettingUsecase createUserSettingUsecase;
+	private final EnabledMatchingSettingUsecase enabledMatchingSettingUsecase;
 	private final FindEnableMatchingUserUsecase	findEnableMatchingUserUsecase;
 	private final KafkaPayloadDeserializer deserializer;
 
@@ -34,7 +37,7 @@ public class UserSettingEventListener {
 	public void create(@Payload String payload, Acknowledgment acknowledgment) {
 		UserCreatedEvent event = deserializer.deserialize(payload, UserCreatedEvent.class);
 		try {
-			usecase.create(CreateUserSettingCommand.of(event.userId(), event.gender()));
+			createUserSettingUsecase.create(CreateUserSettingCommand.of(event.userId(), event.gender()));
 			acknowledgment.acknowledge();
 		} catch (BusinessException e) {
 			log.warn("[UserSetting] already exists: userId: {}", event.userId());
@@ -74,6 +77,48 @@ public class UserSettingEventListener {
 		} catch (Exception e) {
 			log.warn("[USER_SETTING_LISTENER] 매칭 후보 찾기 재시도(unknown 에러) : userId: {}, error: {}",
 				event.hostUserId(), e.getMessage());
+			throw e;
+		}
+	}
+
+	@KafkaListener(
+		topics = "mate.subscribed",
+		groupId = "matching-usersetting-group",
+		containerFactory = "kafkaListenerContainerFactory"
+	)
+	public void mateSubscribed(String payload, Acknowledgment acknowledgment) {
+		MateConnectEvent.Subscribe event = deserializer.deserialize(payload, MateConnectEvent.Subscribe.class);
+		try {
+			enabledMatchingSettingUsecase.activateMatching(event.userId());
+			acknowledgment.acknowledge();
+		} catch (BusinessException e) {
+			log.warn("[USER_SETTING_LISTENER] 메이트 매칭 가능 상태 true 변경 실패(비즈니스 에러): userId = {}, error = {}",
+				event.userId(), e.getMessage(), e);
+			acknowledgment.acknowledge();
+		} catch (Exception e) {
+			log.warn("[USER_SETTING_LISTENER] 메이트 매칭 가능 상태 true 재시도(unknown 에러): userId = {}, error = {}",
+				event.userId(), e.getMessage(), e);
+			throw e;
+		}
+	}
+
+	@KafkaListener(
+		topics = "mate.unsubscribed",
+		groupId = "matching-usersetting-group",
+		containerFactory = "kafkaListenerContainerFactory"
+	)
+	public void mateUnsubscribed(String payload, Acknowledgment acknowledgment) {
+		MateConnectEvent.Unsubscribe event = deserializer.deserialize(payload, MateConnectEvent.Unsubscribe.class);
+		try {
+			enabledMatchingSettingUsecase.deactivateMatching(event.userId());
+			acknowledgment.acknowledge();
+		} catch (BusinessException e) {
+			log.warn("[USER_SETTING_LISTENER] 메이트 매칭 가능 상태 false 변경 실패(비즈니스 에러): userId = {}, error = {}",
+				event.userId(), e.getMessage(), e);
+			acknowledgment.acknowledge();
+		} catch (Exception e) {
+			log.warn("[USER_SETTING_LISTENER] 메이트 매칭 가능 상태 false 재시도(unknown 에러): userId = {}, error = {}",
+				event.userId(), e.getMessage(), e);
 			throw e;
 		}
 	}

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/presentation/UserSettingController.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/presentation/UserSettingController.java
@@ -52,24 +52,4 @@ public class UserSettingController {
 			))
 		);
 	}
-
-	@PatchMapping("/activation")
-	public ResponseEntity<ApiResponse<Void>> activateMatching(
-		@LoginUser UserContext userContext
-	) {
-		userSettingCommandService.activateMatching(userContext.userId());
-		return ResponseEntity.status(EDIT_SUCCESS.getStatus()).body(
-			ApiResponse.success(ACTIVATE_MATCHING, null)
-		);
-	}
-
-	@PatchMapping("/deactivation")
-	public ResponseEntity<ApiResponse<Void>> deactivateMatching(
-		@LoginUser UserContext userContext
-	) {
-		userSettingCommandService.deactivateMatching(userContext.userId());
-		return ResponseEntity.status(EDIT_SUCCESS.getStatus()).body(
-			ApiResponse.success(DEACTIVATE_MATCHING, null)
-		);
-	}
 }


### PR DESCRIPTION
## PR Summary

### summary

기존에 별도 API(`PATCH /user-settings/activation`)를 통해 메이트가 직접 매칭 활성화를 해야 했던 방식을 제거하고, SSE 구독/해제 시 자동으로 `matchingEnabled` 상태가 변경되도록 개선했습니다. 서비스 간 통신은 기존 아키텍처와 일관되게 Kafka + Outbox 패턴을 사용했습니다.

### changes

- `MateConnectEvent` payload 추가 (`Subscribe`, `Unsubscribe` record)
- `MatchingTopic`에 `MATE_SUBSCRIBED_TOPIC`, `MATE_UNSUBSCRIBED_TOPIC` 상수 추가
- `MatchingEventPort` 인터페이스에 `appendMateSubscribed()`, `appendMateUnsubscribed()` 추가
- `MatchingEventPortAdapter`에 mate 구독/해제 Outbox 저장 구현
- `MatchingRedisSseManager` SSE 연결 종료 시 (`onCompletion`, `onTimeout`, `onError`) `mate.unsubscribed` 이벤트 발행
- `SubscriptionUsecase` 인터페이스 분리 및 `SubscriptionUsecaseAdapter` 구현, 컨트롤러 의존 변경
- `UserSettingEventListener`에 `mate.subscribed`, `mate.unsubscribed` Kafka 리스너 추가
- `EnabledMatchingSettingUsecase` 인터페이스 추가, `UserSettingCommandService`에 `activateMatching()`, `deactivateMatching()` 구현
- `/user-settings/activation`, `/user-settings/deactivation` API 제거