### PR TITLE
fix: 재구독 시 mate.unsubscribed 이벤트 중복 발행 방지

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/sse/MatchingRedisSseManager.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/sse/MatchingRedisSseManager.java
@@ -64,15 +64,14 @@ public class MatchingRedisSseManager implements MatchingSseManager {
 
 	@Override
 	public void disconnect(UUID userId) {
-		cleanup(userId);
-		eventPort.appendMateUnsubscribed(userId);
+		cleanupSilently(userId);
 	}
 
 	private void registerMatchingListener(UUID userId, SseEmitter emitter) {
 		ChannelTopic topic = new ChannelTopic(CHANNEL_PREFIX + userId);
 		MessageListener listener = (message, pattern) -> {
 			try {
-				log.info("[SSE] Redis 메시지 수신 - userId: {}", userId); // 추가
+				log.info("[SSE] Redis 메시지 수신 - userId: {}", userId);
 				MatchingSsePayload payload = objectMapper.readValue(
 					message.getBody(), MatchingSsePayload.class
 				);
@@ -120,6 +119,21 @@ public class MatchingRedisSseManager implements MatchingSseManager {
 		if (emitter != null) {
 			emitter.complete();
 		}
+		removeListeners(userId);
+	}
+
+	private void cleanupSilently(UUID userId) {
+		SseEmitter emitter = emitters.remove(userId);
+		if (emitter != null) {
+			emitter.onCompletion(() -> {});
+			emitter.onTimeout(() -> {});
+			emitter.onError(e -> {});
+			emitter.complete();
+		}
+		removeListeners(userId);
+	}
+
+	private void removeListeners(UUID userId) {
 		MessageListener listener = listeners.remove(userId);
 		if (listener != null) {
 			listenerContainer.removeMessageListener(


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- disconnect() 호출 시 onCompletion 콜백 제거 후 정리하는 cleanupSilently() 분리
- 재구독 시 disconnect() → cleanupSilently() 사용으로 unsubscribed 이벤트 발행 방지
- 실제 클라이언트 연결 종료 시에만 mate.unsubscribed 발행되도록 수정 

