### PR TITLE
fix: remove redundant mate.unsubscribed event trigger on timeout/error callbacks

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/sse/MatchingRedisSseManager.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/sse/MatchingRedisSseManager.java
@@ -54,12 +54,10 @@ public class MatchingRedisSseManager implements MatchingSseManager {
 		emitter.onTimeout(() -> {
 			log.info("[SSE] onTimeout 호출 - userId: {}", userId);
 			cleanup(userId);
-			eventPort.appendMateUnsubscribed(userId);
 		});
 		emitter.onError(e -> {
 			log.info("[SSE] onError 호출 - userId: {}", userId);
 			cleanup(userId);
-			eventPort.appendMateUnsubscribed(userId);
 		});
 
 		return emitter;


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- remove redundant mate.unsubscribed event trigger on timeout/error callbacks

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- remove redundant mate.unsubscribed event trigger on timeout/error callbacks  
