### PR TITLE
feat: 매칭 거리 1km 필터링 기능 추가

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/matching/application/SubscriptionUsecaseAdapter.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/SubscriptionUsecaseAdapter.java
@@ -2,6 +2,7 @@ package com.yeoljeong.tripmate.matching.application;
 
 import com.yeoljeong.tripmate.matching.application.dto.command.UserMatchingCriteriaCommand;
 import com.yeoljeong.tripmate.matching.application.external.MatchingEventPort;
+import com.yeoljeong.tripmate.matching.application.external.UserGeoStore;
 import com.yeoljeong.tripmate.matching.application.usecase.SubscriptionUsecase;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -15,11 +16,13 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class SubscriptionUsecaseAdapter implements SubscriptionUsecase {
 
 	private final SseSubscriptionService sseSubscriptionService;
+	private final UserGeoStore userGeoStore;
 	private final MatchingEventPort eventPort;
 
 	@Override
 	public SseEmitter execute(UserMatchingCriteriaCommand command) {
 		eventPort.appendMateSubscribed(command.userId());
+		userGeoStore.saveUserLocation(command.userId(), command.latitude(), command.longitude());
 		return sseSubscriptionService.subscribe(command);
 	}
 

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/dto/command/UserMatchingCriteriaCommand.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/dto/command/UserMatchingCriteriaCommand.java
@@ -6,6 +6,8 @@ public record UserMatchingCriteriaCommand(
 	UUID userId,
 	String gender,
 	boolean smoking,
+	Double latitude,
+	Double longitude,
 	String mbtiIE,
 	String mbtiSN,
 	String mbtiTF,

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/external/UserGeoStore.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/external/UserGeoStore.java
@@ -1,0 +1,8 @@
+package com.yeoljeong.tripmate.matching.application.external;
+
+import java.util.UUID;
+
+public interface UserGeoStore {
+	void saveUserLocation(UUID userId, double latitude, double longitude);
+	void removeUserLocation(UUID userId);
+}

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/message/MatchingEventPortAdapter.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/message/MatchingEventPortAdapter.java
@@ -96,6 +96,7 @@ public class MatchingEventPortAdapter implements MatchingEventPort {
 			return new MatchingCreateEvent(
 				EventUtils.getEventHash("matching", matching.getId().toString(), matching.getUpdatedAt()),
 				matching.getId(), matching.getHostUserId(), matching.getTitle(),
+				matching.getLocation().getLat().doubleValue() ,matching.getLocation().getLng().doubleValue(),
 				matching.getMatchingSetting().isAllowSmoking(),
 				matching.getMatchingSetting().getPreferenceMbtiIE().name(),
 				matching.getMatchingSetting().getPreferenceMbtiSN().name(),

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/redis/UserGeoRedisStore.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/redis/UserGeoRedisStore.java
@@ -1,0 +1,29 @@
+package com.yeoljeong.tripmate.matching.infrastructure.redis;
+
+import com.yeoljeong.tripmate.matching.application.external.UserGeoStore;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.geo.Point;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class UserGeoRedisStore implements UserGeoStore {
+
+	private final String GEO_KEY = "matching:geo:users";
+	private final RedisTemplate<String, String> redisTemplate;
+
+
+	@Override
+	public void saveUserLocation(UUID userId, double latitude, double longitude) {
+		redisTemplate.opsForGeo().add(GEO_KEY, new Point(longitude, latitude), userId.toString());
+	}
+
+	@Override
+	public void removeUserLocation(UUID userId) {
+		redisTemplate.opsForGeo().remove(GEO_KEY, userId.toString());
+	}
+}

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/sse/MatchingRedisSseManager.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/sse/MatchingRedisSseManager.java
@@ -5,6 +5,7 @@ import com.yeoljeong.tripmate.common.message.MatchingMatchedPayload;
 import com.yeoljeong.tripmate.common.message.MatchingSsePayload;
 import com.yeoljeong.tripmate.matching.application.external.MatchingEventPort;
 import com.yeoljeong.tripmate.matching.application.external.MatchingSseManager;
+import com.yeoljeong.tripmate.matching.application.external.UserGeoStore;
 import java.io.IOException;
 import java.util.Map;
 import java.util.UUID;
@@ -34,6 +35,7 @@ public class MatchingRedisSseManager implements MatchingSseManager {
 	private final RedisMessageListenerContainer listenerContainer;
 	private final ObjectMapper objectMapper;
 
+	private final UserGeoStore userGeoStore;
 	private final MatchingEventPort eventPort;
 
 	@Override
@@ -50,6 +52,7 @@ public class MatchingRedisSseManager implements MatchingSseManager {
 			log.info("[SSE] onCompletion 호출 - userId: {}", userId);
 			cleanup(userId);
 			eventPort.appendMateUnsubscribed(userId);
+			userGeoStore.removeUserLocation(userId);
 		});
 		emitter.onTimeout(() -> {
 			log.info("[SSE] onTimeout 호출 - userId: {}", userId);

--- a/src/main/java/com/yeoljeong/tripmate/matching/presentation/dto/request/UserMatchingCriteriaRequest.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/presentation/dto/request/UserMatchingCriteriaRequest.java
@@ -1,11 +1,16 @@
 package com.yeoljeong.tripmate.matching.presentation.dto.request;
 
 import com.yeoljeong.tripmate.matching.application.dto.command.UserMatchingCriteriaCommand;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 public record UserMatchingCriteriaRequest (
 	String gender,
 	boolean isSmoking,
+	@NotNull
+	Double latitude,
+	@NotNull
+	Double longitude,
 	String mbtiIE,
 	String mbtiSN,
 	String mbtiTF,
@@ -23,6 +28,8 @@ public record UserMatchingCriteriaRequest (
 			userId,
 			gender,
 			isSmoking,
+			latitude,
+			longitude,
 			mbtiIE,
 			mbtiSN,
 			mbtiTF,

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/application/FindEnableMatchingUserUsecaseAdapter.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/application/FindEnableMatchingUserUsecaseAdapter.java
@@ -4,6 +4,7 @@ import com.yeoljeong.tripmate.usersetting.application.dto.command.MatchingCandid
 import com.yeoljeong.tripmate.usersetting.application.external.UserSettingEventPort;
 import com.yeoljeong.tripmate.usersetting.application.usecase.FindEnableMatchingUserUsecase;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -14,13 +15,21 @@ public class FindEnableMatchingUserUsecaseAdapter implements FindEnableMatchingU
 
 	private final UserSettingCommandService userSettingCommandService;
 	private final UserSettingQueryService userSettingQueryService;
+	private final NearbyUserFiltering nearbyUserFiltering;
 	private final UserSettingEventPort userSettingEventPort;
 
 	@Override
 	public void findAllEnableMatchingUser(MatchingCandidateCriteria criteria) {
 		userSettingCommandService.activateMatching(criteria.hostUserId());
+		Set<UUID> nearbyUsers = nearbyUserFiltering.findNearbyUsers(criteria.latitude(),
+			criteria.longitude(), 1.0);
+
+		if (nearbyUsers.isEmpty()) {
+			userSettingEventPort.appendCandidateFound(criteria.matchingId(), criteria.hostUserId(), List.of());
+			return;
+		}
 		List<UUID> candidatesId = userSettingQueryService.findAllEnableMatchingUser(
-			criteria);
+			criteria, nearbyUsers);
 		userSettingEventPort.appendCandidateFound(criteria.matchingId(), criteria.hostUserId(), candidatesId);
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/application/NearbyUserFiltering.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/application/NearbyUserFiltering.java
@@ -1,0 +1,8 @@
+package com.yeoljeong.tripmate.usersetting.application;
+
+import java.util.Set;
+import java.util.UUID;
+
+public interface NearbyUserFiltering {
+	Set<UUID> findNearbyUsers(double latitude, double longitude, double radiusKm);
+}

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/application/UserSettingQueryService.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/application/UserSettingQueryService.java
@@ -8,6 +8,7 @@ import com.yeoljeong.tripmate.usersetting.application.dto.result.UserSettingResu
 import com.yeoljeong.tripmate.usersetting.domain.model.UserSetting;
 import com.yeoljeong.tripmate.usersetting.domain.repository.UserSettingRepository;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,9 +29,15 @@ public class UserSettingQueryService {
 		return UserSettingResult.from(setting);
 	}
 
-	public List<UUID> findAllEnableMatchingUser(MatchingCandidateCriteria criteria) {
-		return userSettingRepository.findCandidateByCriteria(criteria.hostUserId(), criteria.preferenceGender(), criteria.allowSmoking(),
-				criteria.preferenceMbtiIE(), criteria.preferenceMbtiSN(), criteria.preferenceMbtiTF(), criteria.preferenceMbtiPJ())
+	public List<UUID> findAllEnableMatchingUser(MatchingCandidateCriteria criteria,
+		Set<UUID> nearbyUsers) {
+		return userSettingRepository.findCandidateByCriteria(
+				criteria.hostUserId(), criteria.preferenceGender(), criteria.allowSmoking(),
+				criteria.preferenceMbtiIE(),
+				criteria.preferenceMbtiSN(),
+				criteria.preferenceMbtiTF(),
+				criteria.preferenceMbtiPJ(),
+				nearbyUsers)
 			.stream()
 			.map(UserSetting::getUserId)
 			.toList();

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/application/dto/command/MatchingCandidateCriteria.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/application/dto/command/MatchingCandidateCriteria.java
@@ -5,6 +5,8 @@ import java.util.UUID;
 public record MatchingCandidateCriteria(
 	UUID matchingId,
 	UUID hostUserId,
+	Double latitude,
+	Double longitude,
 	boolean allowSmoking,
 	String preferenceMbtiIE,
 	String preferenceMbtiSN,

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/domain/repository/UserSettingRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/domain/repository/UserSettingRepository.java
@@ -3,6 +3,7 @@ package com.yeoljeong.tripmate.usersetting.domain.repository;
 import com.yeoljeong.tripmate.usersetting.domain.model.UserSetting;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 public interface UserSettingRepository {
@@ -10,5 +11,5 @@ public interface UserSettingRepository {
 	boolean existsByUserIdAndIsDeletedFalse(UUID userId);
 	UserSetting save(UserSetting userSetting);
 	List<UserSetting> findCandidateByCriteria(UUID hostUserId, String gender, boolean allowSmoking,
-		String mbtiIE, String mbtiSN, String mbtiTF, String mbtiPJ);
+		String mbtiIE, String mbtiSN, String mbtiTF, String mbtiPJ, Set<UUID> nearbyUsers);
 }

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/message/UserSettingEventListener.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/message/UserSettingEventListener.java
@@ -62,6 +62,8 @@ public class UserSettingEventListener {
 				new MatchingCandidateCriteria(
 					event.matchingId(),
 					event.hostUserId(),
+					event.latitude(),
+					event.longitude(),
 					event.allowSmoking(),
 					event.preferenceMbtiIE(),
 					event.preferenceMbtiSN(),

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/persistence/querydsl/UserSettingQueryDslRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/persistence/querydsl/UserSettingQueryDslRepository.java
@@ -11,6 +11,7 @@ import com.yeoljeong.tripmate.usersetting.domain.model.constants.MbtiPJ;
 import com.yeoljeong.tripmate.usersetting.domain.model.constants.MbtiSN;
 import com.yeoljeong.tripmate.usersetting.domain.model.constants.MbtiTF;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -23,13 +24,14 @@ public class UserSettingQueryDslRepository {
 	private final QUserSetting userSetting = QUserSetting.userSetting;
 
 	public List<UserSetting> findCandidatesByCriteria(UUID hostUserId, String preferenceGender, boolean allowSmoking,
-		String preferenceMbtiIE, String preferenceMbtiSN, String preferenceMbtiTF, String preferenceMbtiPJ
+		String preferenceMbtiIE, String preferenceMbtiSN, String preferenceMbtiTF, String preferenceMbtiPJ, Set<UUID> nearbyUsers
 	) {
 		return jpaQueryFactory.selectFrom(userSetting)
 			.where(
 				userSetting.matchingEnabled.isTrue(),
 				userSetting.isDeleted.isFalse(),
 				userSetting.userId.ne(hostUserId),
+				userSetting.userId.in(nearbyUsers),
 				smokingCondition(allowSmoking),
 				genderCondition(preferenceGender),
 				mbtiCondition(

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/persistence/repositoryimpl/UserSettingRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/persistence/repositoryimpl/UserSettingRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.yeoljeong.tripmate.usersetting.infrastructure.persistence.jpa.UserSet
 import com.yeoljeong.tripmate.usersetting.infrastructure.persistence.querydsl.UserSettingQueryDslRepository;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -34,9 +35,9 @@ public class UserSettingRepositoryImpl implements UserSettingRepository {
 
 	@Override
 	public List<UserSetting> findCandidateByCriteria(UUID hostUserId, String gender,
-		boolean allowSmoking, String mbtiIE, String mbtiSN, String mbtiTF, String mbtiPJ) {
+		boolean allowSmoking, String mbtiIE, String mbtiSN, String mbtiTF, String mbtiPJ, Set<UUID> nearbyUsers) {
 		return userSettingQueryDslRepository.findCandidatesByCriteria(
-			hostUserId, gender, allowSmoking, mbtiIE, mbtiSN, mbtiTF, mbtiPJ
+			hostUserId, gender, allowSmoking, mbtiIE, mbtiSN, mbtiTF, mbtiPJ, nearbyUsers
 		);
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/redis/RedisNearbyFiltering.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/redis/RedisNearbyFiltering.java
@@ -1,0 +1,38 @@
+package com.yeoljeong.tripmate.usersetting.infrastructure.redis;
+
+import com.yeoljeong.tripmate.usersetting.application.NearbyUserFiltering;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.geo.Circle;
+import org.springframework.data.geo.Distance;
+import org.springframework.data.geo.GeoResults;
+import org.springframework.data.geo.Metrics;
+import org.springframework.data.geo.Point;
+import org.springframework.data.redis.connection.RedisGeoCommands.GeoLocation;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RedisNearbyFiltering implements NearbyUserFiltering {
+
+	private final static String GEO_KEY = "matching:geo:users";
+	private final RedisTemplate<String, String> redisTemplate;
+
+
+	@Override
+	public Set<UUID> findNearbyUsers(double latitude, double longitude, double radiusKm) {
+		GeoResults<GeoLocation<String>> results = redisTemplate.opsForGeo()
+			.search(GEO_KEY,
+				new Circle(new Point(longitude, latitude), new Distance(radiusKm, Metrics.KILOMETERS)));
+
+		if (results == null) return Set.of();
+		return results.getContent().stream()
+			.map(r -> UUID.fromString(r.getContent().getName()))
+			.collect(Collectors.toSet());
+	}
+}


### PR DESCRIPTION
### summary
SSE 구독 시 메이트의 현재 위치(lat, lng)를 Redis GEO에 저장하고, 매칭 생성 이벤트 수신 시 1km 반경 내 유저를 먼저 필터링한 후 MBTI/흡연여부/성별 조건으로 DB 필터링하는 2단계 후보군 필터링을 구현했습니다. 기존에 DB 필터링만 했던 방식에서 Redis GEO 기반 거리 필터링이 추가되어 위치 기반 매칭이 가능해졌습니다.

### changes
- `UserMatchingCriteriaRequest`, `UserMatchingCriteriaCommand`에 `latitude`, `longitude` 추가
- `MatchingCreateEvent`에 `latitude`, `longitude` 추가
- `MatchingCandidateCriteria`에 `latitude`, `longitude` 추가
- `UserGeoStore` 인터페이스 추가 (matching-service application/external)
- `UserGeoRedisStore` 구현체 추가 (matching-service infrastructure/redis)
- `NearbyUserFiltering` 인터페이스 추가 (user-settings-service application/external)
- `RedisNearbyFiltering` 구현체 추가 (user-settings-service infrastructure/redis)
- `SubscriptionUsecaseAdapter` — SSE 구독 시 Redis GEO에 위치 저장 추가
- `MatchingRedisSseManager` — SSE 연결 해제 시 Redis GEO에서 위치 제거 추가
- `FindEnableMatchingUserUsecaseAdapter` — Redis GEO 거리 필터링 후 DB 필터링 순서로 변경
- `UserSettingQueryDslRepository` — `nearbyUsers` IN 절 조건 추가
- `UserSettingQueryService`, `UserSettingRepository`, `UserSettingRepositoryImpl` — `nearbyUsers` 파라미터 추가
- `MatchingEventPortAdapter` — `toMatchingCreatedEvent`에 lat, lng 추가

### background
- 메이트가 SSE 구독 시 반드시 `latitude`, `longitude` 쿼리파라미터를 전달해야 합니다. 없으면 400 에러가 반환됩니다.
- Redis GEO 키는 `matching:geo:users`로 matching-service와 user-settings-service가 같은 Redis를 바라봐야 합니다.
- 거리 기준은 현재 1km로 하드코딩되어 있습니다.