### PR TITLE
chore: 매칭 시작 시 내 정보를 조회해서 매칭조회하도록 변경

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/matching/application/NearbyUserFiltering.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/NearbyUserFiltering.java
@@ -1,0 +1,8 @@
+package com.yeoljeong.tripmate.matching.application;
+
+import java.util.Set;
+import java.util.UUID;
+
+public interface NearbyUserFiltering {
+	Set<UUID> findNearbyUsers(double latitude, double longitude, double radiusKm);
+}

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/SseSubscriptionService.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/SseSubscriptionService.java
@@ -1,11 +1,14 @@
 package com.yeoljeong.tripmate.matching.application;
 
 import com.yeoljeong.tripmate.matching.application.dto.command.UserMatchingCriteriaCommand;
+import com.yeoljeong.tripmate.matching.application.dto.result.UserSettingInfo;
 import com.yeoljeong.tripmate.matching.application.external.MatchingNotifier;
 import com.yeoljeong.tripmate.matching.application.external.MatchingSseManager;
+import com.yeoljeong.tripmate.matching.application.external.UserSettingPort;
 import com.yeoljeong.tripmate.matching.domain.model.Matching;
 import com.yeoljeong.tripmate.matching.domain.repository.MatchingRepository;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,19 +22,29 @@ public class SseSubscriptionService {
 	private final MatchingSseManager sseManager;
 	private final MatchingRepository repository;
 	private final MatchingNotifier candidateNotifier;
+	private final UserSettingPort userSettingPort;
+	private final NearbyUserFiltering nearbyUserFiltering;
 
 	@Transactional(readOnly = true)
 	public SseEmitter subscribe(UserMatchingCriteriaCommand command) {
 		SseEmitter emitter = sseManager.subscribe(command.userId());
-
+		UserSettingInfo setting = userSettingPort.getUserSetting(command.userId());
+		Set<UUID> nearbyUsers = nearbyUserFiltering.findNearbyUsers(
+			command.latitude(), command.longitude(), 1.0
+		);
 		List<Matching> openMatchings = repository.findAllByCriteria(
-			command.userId(), command.gender(), command.smoking(),
-			command.mbtiIE(), command.mbtiSN(), command.mbtiTF(), command.mbtiPJ()
+			setting.userId(),
+			setting.gender(),
+			setting.isSmoking(),
+			setting.mbtiIE(),
+			setting.mbtiSN(),
+			setting.mbtiTF(),
+			setting.mbtiPJ()
 		);
 
-		openMatchings.forEach(
-			matching -> candidateNotifier.publishToUserDirect(command.userId(), matching)
-		);
+		openMatchings.stream()
+			.filter(matching -> nearbyUsers.contains(matching.getHostUserId()))
+			.forEach(matching -> candidateNotifier.publishToUserDirect(command.userId(), matching));
 		return emitter;
 	}
 

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/dto/command/UserMatchingCriteriaCommand.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/dto/command/UserMatchingCriteriaCommand.java
@@ -4,13 +4,7 @@ import java.util.UUID;
 
 public record UserMatchingCriteriaCommand(
 	UUID userId,
-	String gender,
-	boolean smoking,
 	Double latitude,
-	Double longitude,
-	String mbtiIE,
-	String mbtiSN,
-	String mbtiTF,
-	String mbtiPJ
+	Double longitude
 ) {
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/dto/result/UserSettingInfo.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/dto/result/UserSettingInfo.java
@@ -1,0 +1,15 @@
+package com.yeoljeong.tripmate.matching.application.dto.result;
+
+import java.util.UUID;
+
+public record UserSettingInfo (
+	UUID userId,
+	String gender,
+	boolean isSmoking,
+	String mbtiIE,
+	String mbtiSN,
+	String mbtiTF,
+	String mbtiPJ
+) {
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/external/UserSettingPort.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/external/UserSettingPort.java
@@ -1,0 +1,8 @@
+package com.yeoljeong.tripmate.matching.application.external;
+
+import com.yeoljeong.tripmate.matching.application.dto.result.UserSettingInfo;
+import java.util.UUID;
+
+public interface UserSettingPort {
+	UserSettingInfo getUserSetting(UUID userId);
+}

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/feign/UserSettingClient.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/feign/UserSettingClient.java
@@ -1,0 +1,28 @@
+package com.yeoljeong.tripmate.matching.infrastructure.feign;
+
+import com.yeoljeong.tripmate.matching.infrastructure.feign.dto.UserSettingResponse;
+import com.yeoljeong.tripmate.usersetting.application.UserSettingQueryService;
+import com.yeoljeong.tripmate.usersetting.application.dto.result.UserSettingResult;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserSettingClient {
+
+	private final UserSettingQueryService userSettingQueryService;
+
+	public UserSettingResponse getMySetting(UUID userId) {
+		UserSettingResult result = userSettingQueryService.getOne(userId);
+		return new UserSettingResponse(
+			result.userId(),
+			result.gender().name(),
+			result.isSmoking(),
+			result.mbtiIE().name(),
+			result.mbtiSN().name(),
+			result.mbtiTF().name(),
+			result.mbtiPJ().name()
+		);
+	}
+}

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/feign/UserSettingPortAdapter.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/feign/UserSettingPortAdapter.java
@@ -1,0 +1,26 @@
+package com.yeoljeong.tripmate.matching.infrastructure.feign;
+
+import com.yeoljeong.tripmate.matching.application.dto.result.UserSettingInfo;
+import com.yeoljeong.tripmate.matching.application.external.UserSettingPort;
+import com.yeoljeong.tripmate.matching.infrastructure.feign.dto.UserSettingResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UserSettingPortAdapter implements UserSettingPort {
+
+	private final UserSettingClient userSettingClient;
+
+	@Override
+	public UserSettingInfo getUserSetting(UUID userId) {
+		UserSettingResponse response = userSettingClient.getMySetting(userId);
+		return new UserSettingInfo(
+			response.userId(), response.gender(), response.isSmoking(),
+			response.mbtiIE(), response.mbtiSN(), response.mbtiTF(), response.mbtiPJ()
+		);
+	}
+}

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/feign/dto/UserSettingResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/feign/dto/UserSettingResponse.java
@@ -1,0 +1,27 @@
+package com.yeoljeong.tripmate.matching.infrastructure.feign.dto;
+
+import java.util.UUID;
+
+public record UserSettingResponse (
+	UUID userId,
+	String gender,
+	boolean isSmoking,
+	String mbtiIE,
+	String mbtiSN,
+	String mbtiTF,
+	String mbtiPJ
+) {
+	public static UserSettingResponse of(
+		UUID userId,
+		String gender,
+		boolean isSmoking,
+		String mbtiIE,
+		String mbtiSN,
+		String mbtiTF,
+		String mbtiPJ
+	) {
+		return new UserSettingResponse(
+			userId, gender, isSmoking, mbtiIE, mbtiSN, mbtiTF, mbtiPJ
+		);
+	}
+}

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/redis/RedisNearbyFiltering.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/redis/RedisNearbyFiltering.java
@@ -1,0 +1,38 @@
+package com.yeoljeong.tripmate.matching.infrastructure.redis;
+
+import com.yeoljeong.tripmate.matching.application.NearbyUserFiltering;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.geo.Circle;
+import org.springframework.data.geo.Distance;
+import org.springframework.data.geo.GeoResults;
+import org.springframework.data.geo.Metrics;
+import org.springframework.data.geo.Point;
+import org.springframework.data.redis.connection.RedisGeoCommands.GeoLocation;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RedisNearbyFiltering implements NearbyUserFiltering {
+
+	private final static String GEO_KEY = "matching:geo:users";
+	private final RedisTemplate<String, String> redisTemplate;
+
+
+	@Override
+	public Set<UUID> findNearbyUsers(double latitude, double longitude, double radiusKm) {
+		GeoResults<GeoLocation<String>> results = redisTemplate.opsForGeo()
+			.search(GEO_KEY,
+				new Circle(new Point(longitude, latitude), new Distance(radiusKm, Metrics.KILOMETERS)));
+
+		if (results == null) return Set.of();
+		return results.getContent().stream()
+			.map(r -> UUID.fromString(r.getContent().getName()))
+			.collect(Collectors.toSet());
+	}
+}

--- a/src/main/java/com/yeoljeong/tripmate/matching/presentation/dto/request/UserMatchingCriteriaRequest.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/presentation/dto/request/UserMatchingCriteriaRequest.java
@@ -5,35 +5,13 @@ import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 public record UserMatchingCriteriaRequest (
-	String gender,
-	boolean isSmoking,
 	@NotNull
 	Double lat,
 	@NotNull
-	Double lng,
-	String mbtiIE,
-	String mbtiSN,
-	String mbtiTF,
-	String mbtiPJ
+	Double lng
 ){
-	public UserMatchingCriteriaRequest {
-		mbtiIE = mbtiIE == null ? "UNKNOWN" : mbtiIE;
-		mbtiSN = mbtiSN == null ? "UNKNOWN" : mbtiSN;
-		mbtiTF = mbtiTF == null ? "UNKNOWN" : mbtiTF;
-		mbtiPJ = mbtiPJ == null ? "UNKNOWN" : mbtiPJ;
-	}
 
 	public UserMatchingCriteriaCommand toCommand(UUID userId) {
-		return new UserMatchingCriteriaCommand(
-			userId,
-			gender,
-			isSmoking,
-			lat,
-			lng,
-			mbtiIE,
-			mbtiSN,
-			mbtiTF,
-			mbtiPJ
-		);
+		return new UserMatchingCriteriaCommand(userId, lat, lng);
 	}
 }


### PR DESCRIPTION
### summary
- SSE 구독 시점에 이미 생성된 OPEN 매칭방을 즉시 수신할 수 있도록 구현했습니다. 기존에는 구독 이전에 생성된 매칭방을 볼 수 없었으나, 구독 시점에 조건(성별, 흡연, MBTI) + 거리 필터링을 거쳐 적합한 매칭방을 즉시 SSE로 전달합니다. 또한 매칭 조건을 클라이언트 쿼리파라미터가 아닌 서버에서 직접 조회하도록 변경해 신뢰성을 확보했습니다.

### changes
- **추가** `NearbyUserFiltering` 인터페이스 — matching-service application 계층에 Redis GEO 조회 포트 추가
- **추가** `RedisNearbyFiltering` — Redis GEO 기반 반경 1km 내 유저 조회 구현체
- **추가** `UserSettingPort` / `UserSettingPortAdapter` / `UserSettingClient` — user-settings 조회 포트 및 어댑터 (같은 BC 내부 직접 호출)
- **추가** `UserSettingInfo` — user-settings 조회 결과 Result DTO
- **수정** `UserMatchingCriteriaCommand` — gender, smoking, mbti 필드 제거, lat/lng만 유지
- **수정** `UserMatchingCriteriaRequest` — 동일하게 lat/lng만 받도록 단순화, `@NotNull` 검증 추가
- **수정** `SseSubscriptionService.subscribe()` — 내부에서 UserSettingPort로 조건 조회 + NearbyUserFiltering으로 거리 필터링 후 OPEN 매칭방 즉시 전송
- **추가** `MatchingExceptionHandler` — SSE 컨텍스트에서 `MethodArgumentNotValidException` 발생 시 `text/plain`으로 응답, `AsyncRequestTimeoutException` 정상 종료 처리

### background
- 매칭 조건(성별, 흡연, MBTI)은 더 이상 클라이언트가 쿼리파라미터로 전달하지 않습니다. 서버가 JWT의 userId로 직접 조회하므로 API 명세서에서 해당 파라미터를 제거해야 합니다.
- `UserSettingClient`는 FeignClient가 아닌 같은 바운디드 컨텍스트 내부 직접 호출입니다. user-settings가 matching BC 내부 애그리거트이기 때문에 의도된 구조입니다.
- SSE 엔드포인트에서 `@Valid` 실패 시 `GlobalExceptionHandler`가 `text/event-stream` 컨텍스트와 충돌하는 문제가 있었습니다. `MatchingExceptionHandler`를 `MatchingController` 범위로 한정해 해결했습니다.