### PR TITLE
feat: 매칭 성사 정보 전달 기능 구현

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/common/message/MatchingMatchedPayload.java
+++ b/src/main/java/com/yeoljeong/tripmate/common/message/MatchingMatchedPayload.java
@@ -3,7 +3,12 @@ package com.yeoljeong.tripmate.common.message;
 import java.util.UUID;
 
 public record MatchingMatchedPayload(
-	UUID matchingId
+	UUID matchingId,
+	UUID hostUserId,
+	UUID mateUserId,
+	String chatUrl,
+	String title,
+	String description
 ) {
 
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/MatchingAcceptUsecaseAdapter.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/MatchingAcceptUsecaseAdapter.java
@@ -1,6 +1,7 @@
 package com.yeoljeong.tripmate.matching.application;
 
 import com.yeoljeong.tripmate.matching.application.external.MatchingEventPort;
+import com.yeoljeong.tripmate.matching.application.external.MatchingNotifier;
 import com.yeoljeong.tripmate.matching.application.external.UserGeoStore;
 import com.yeoljeong.tripmate.matching.application.usecase.MatchingAcceptUsecase;
 import java.util.UUID;
@@ -15,12 +16,15 @@ public class MatchingAcceptUsecaseAdapter implements MatchingAcceptUsecase {
 
 	private final MatchingEventPort matchingEventPort;
 	private final MatchingCommandService matchingCommandService;
+	private final MatchingNotifier matchingNotifier;
 	private final UserGeoStore userGeoStore;
 
 	@Override
 	public void accept(UUID userId, UUID matchingId) {
 		var matching = matchingCommandService.accept(userId, matchingId);
 		userGeoStore.removeUserLocation(matching.getHostUserId());
+		matchingNotifier.publishClosedToUser(matching.getHostUserId(), matching);
+		matchingNotifier.publishClosedToUser(matching.getMateUserId(), matching);
 		matchingEventPort.appendMatchingAccomplished(matching);
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/MatchingNotificationService.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/MatchingNotificationService.java
@@ -40,7 +40,8 @@ public class MatchingNotificationService implements NotifyMatchingCandidatesUsec
 		List<UUID> failed = new ArrayList<>();
 		candidates.forEach(userId -> {
 			try {
-				matchingNotifier.publishClosedToUser(userId, matchingId);
+				Matching matching = getMatching(matchingId);
+				matchingNotifier.publishClosedToUser(userId, matching);
 			} catch (Exception e) {
 				log.error("[Matching] closed 이벤트 전송 실패 - userId: {}, error: {}", userId, e.getMessage(), e);
 				failed.add(userId);
@@ -51,5 +52,10 @@ public class MatchingNotificationService implements NotifyMatchingCandidatesUsec
 		} else {
 			log.error("[Matching] 일부 candidates 전송 실패 - 실패 수: {}", failed.size());
 		}
+	}
+
+	private Matching getMatching(UUID matchingId) {
+		return repository.findByIdAndIsDeletedFalse(matchingId)
+			.orElseThrow(() -> new BusinessException(NO_ACTIVE_MATCHING));
 	}
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/external/MatchingNotifier.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/external/MatchingNotifier.java
@@ -7,5 +7,5 @@ import java.util.UUID;
 public interface MatchingNotifier {
 	void publishToUsers(List<UUID> userIds, Matching matching);
 	void publishToUserDirect(UUID userId, Matching matching);
-	void publishClosedToUser(UUID userId, UUID matchingId);
+	void publishClosedToUser(UUID userId, Matching matching);
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/message/MatchingSseRedisPublisher.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/message/MatchingSseRedisPublisher.java
@@ -34,11 +34,11 @@ public class MatchingSseRedisPublisher implements MatchingNotifier {
 	}
 
 	@Override
-	public void publishClosedToUser(UUID userId, UUID matchingId) {
+	public void publishClosedToUser(UUID userId, Matching matching) {
 		String channel = CLOSED_CHANNEL_PREFIX + userId;
 		try {
-			redisTemplate.convertAndSend(channel, new MatchingMatchedPayload(matchingId));
-			log.debug("[MatchingSSE] 매칭 종료 전송 - userId: {}, matchingId: {}", userId, matchingId);
+			redisTemplate.convertAndSend(channel, toMatchingMatchedPayload(matching));
+			log.debug("[MatchingSSE] 매칭 종료 전송 - userId: {}, matchingId: {}", userId, matching.getId());
 		} catch (Exception e) {
 			log.error("[MatchingSSE] 매칭 종료 전송 실패 - channel: {}, error : {}]", channel, e.getMessage(), e);
 			throw e;
@@ -74,6 +74,17 @@ public class MatchingSseRedisPublisher implements MatchingNotifier {
 		return new MatchingSsePayload(
 			matching.getId(),
 			matching.getHostUserId(),
+			matching.getTitle(),
+			matching.getDescription()
+		);
+	}
+
+	private MatchingMatchedPayload toMatchingMatchedPayload(Matching matching) {
+		return new MatchingMatchedPayload(
+			matching.getId(),
+			matching.getHostUserId(),
+			matching.getMateUserId(),
+			matching.getChatUrl(),
 			matching.getTitle(),
 			matching.getDescription()
 		);

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/sse/MatchingRedisSseManager.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/sse/MatchingRedisSseManager.java
@@ -107,6 +107,7 @@ public class MatchingRedisSseManager implements MatchingSseManager {
 						.name("matching-closed")
 						.data(payload)
 				);
+				emitter.complete();
 			} catch (IOException e) {
 				log.error("[MatchingSSE] closed 이벤트 전송 실패 - userId: {}", userId);
 				cleanup(userId);


### PR DESCRIPTION
### summary
- 매칭 수락 시 호스트와 메이트 모두에게 성사된 매칭 정보를 SSE로 전달하고 연결을 종료합니다. 기존에는 후보군 전체에게 matchingId만 전달하는 구조였으나, 매칭 성사 정보(hostUserId, mateUserId, chatUrl, title, description)를 포함하도록 개선했습니다.

### changes
- **수정** `MatchingMatchedPayload` — matchingId만 있던 구조에서 hostUserId, mateUserId, chatUrl, title, description 필드 추가
- **수정** `MatchingNotifier` — `publishClosedToUser(UUID userId, UUID matchingId)` → `publishClosedToUser(UUID userId, Matching matching)`으로 시그니처 변경, `publishMatchedToUser` 별도 메서드 없이 통일
- **수정** `MatchingSseRedisPublisher.publishClosedToUser()` — Matching 객체에서 payload 생성하도록 변경, `toMatchingMatchedPayload()` private 메서드 추가
- **수정** `MatchingNotificationService.sendMatchingAccomplished()` — matchingId로 Matching 조회 후 `publishClosedToUser(userId, matching)` 호출로 변경
- **수정** `MatchingAcceptUsecaseAdapter` — 호스트/메이트 각각 `publishClosedToUser()` 호출 추가
- **수정** `MatchingRedisSseManager.registerCloseListener()` — SSE 전송 후 `emitter.complete()` 추가해 서버에서도 연결 종료 처리

### background
- `publishClosedToUser`는 호스트/메이트(성사 알림)와 나머지 후보군(마감 알림) 모두 동일한 채널(`matching:sse:closed:{userId}`)과 payload를 사용합니다. 클라이언트는 `matching-closed` 이벤트 하나로 처리하면 됩니다.
- 호스트와 메이트 모두 SSE 구독 시점에 `registerCloseListener()`가 실행되므로 `matching:sse:closed:{userId}` 채널을 구독하고 있습니다. accept() 호출 전에 반드시 양쪽 모두 구독 상태여야 정상 수신됩니다.
- `emitter.complete()` 호출 시 `onCompletion` 콜백이 실행되어 Redis 리스너 제거 및 GEO 정리까지 자동으로 처리됩니다.