### PR TITLE
feat: redisson을 이용한 분산락 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.27.0'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'

--- a/src/main/java/com/yeoljeong/tripmate/common/aop/TripmateLock.java
+++ b/src/main/java/com/yeoljeong/tripmate/common/aop/TripmateLock.java
@@ -13,6 +13,6 @@ import java.lang.annotation.Target;
 @Inherited
 public @interface TripmateLock {
 	String key();
-	long tryLockTime();
-	long leaseTime();
+	long tryLockTime() default 5000L;
+	long leaseTime() default 15000L;
 }

--- a/src/main/java/com/yeoljeong/tripmate/common/aop/TripmateLock.java
+++ b/src/main/java/com/yeoljeong/tripmate/common/aop/TripmateLock.java
@@ -1,0 +1,4 @@
+package com.yeoljeong.tripmate.common.aop;
+
+public @interface TripmateLock {
+}

--- a/src/main/java/com/yeoljeong/tripmate/common/aop/TripmateLock.java
+++ b/src/main/java/com/yeoljeong/tripmate/common/aop/TripmateLock.java
@@ -1,4 +1,18 @@
 package com.yeoljeong.tripmate.common.aop;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
 public @interface TripmateLock {
+	String key();
+	long tryLockTime();
+	long leaseTime();
 }

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/MatchingCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/MatchingCommandService.java
@@ -1,5 +1,6 @@
 package com.yeoljeong.tripmate.matching.application;
 
+import com.yeoljeong.tripmate.common.aop.TripmateLock;
 import com.yeoljeong.tripmate.exception.BusinessException;
 import com.yeoljeong.tripmate.matching.application.dto.command.CreateMatchingCommand;
 import com.yeoljeong.tripmate.matching.domain.exception.MatchingErrorCode;
@@ -39,6 +40,7 @@ public class MatchingCommandService {
 		return repository.save(matching);
 	}
 
+	@TripmateLock(key = "'matching:accept' + #matchingId")
 	public Matching accept(UUID userId, UUID matchingId) {
 		Matching matching = repository.findByIdAndIsDeletedFalse(matchingId)
 			.orElseThrow(() -> new BusinessException(MatchingErrorCode.NO_ACTIVE_MATCHING));

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/aop/MatchingLockService.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/aop/MatchingLockService.java
@@ -1,0 +1,6 @@
+package com.yeoljeong.tripmate.matching.application.aop;
+
+public interface MatchingLockService {
+	void lock(String key, long tryLockTime, long leaseTime);
+	void unlock(String key);
+}

--- a/src/main/java/com/yeoljeong/tripmate/matching/application/aop/TripmateLockAspect.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/application/aop/TripmateLockAspect.java
@@ -1,0 +1,48 @@
+package com.yeoljeong.tripmate.matching.application.aop;
+
+import com.yeoljeong.tripmate.common.aop.TripmateLock;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class TripmateLockAspect {
+
+	private final MatchingLockService lockService;
+	private final ExpressionParser parser = new SpelExpressionParser();
+
+	@Around("@annotation(tripmateLock)")
+	public Object aroundMethod(
+		ProceedingJoinPoint pjp, TripmateLock tripmateLock
+	) throws Throwable {
+		String key = resolveKey(pjp, tripmateLock.key());
+		lockService.lock(key, tripmateLock.tryLockTime(), tripmateLock.leaseTime());
+		try {
+			return pjp.proceed();
+		} finally {
+			lockService.unlock(key);
+		}
+	}
+
+	private String resolveKey(ProceedingJoinPoint pjp, String keyExpression) {
+		MethodSignature signature = (MethodSignature) pjp.getSignature();
+		String[] paramNames = signature.getParameterNames();
+		Object[] args = pjp.getArgs();
+
+		StandardEvaluationContext context = new StandardEvaluationContext();
+		for (int i = 0; i < paramNames.length; i++) {
+			context.setVariable(paramNames[i], args[i]);
+		}
+		return parser.parseExpression(keyExpression).getValue(context, String.class);
+	}
+}

--- a/src/main/java/com/yeoljeong/tripmate/matching/domain/exception/MatchingErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/domain/exception/MatchingErrorCode.java
@@ -16,6 +16,7 @@ public enum MatchingErrorCode implements ErrorCode {
 	NO_ACTIVE_MATCHING(HttpStatus.NOT_FOUND, "진행 중인 매칭정보가 없습니다."),
 	HOST_CANNOT_ACCEPT_OWN_MATCHING(HttpStatus.BAD_REQUEST, "호스트 본인의 매칭을 수락할 수 없습니다."),
 	MATCHING_ALREADY_MATCHED(HttpStatus.CONFLICT, "이미 매칭이 완성된 방입니다"),
+	MATCHING_LOCK_FAILED(HttpStatus.CONFLICT, "현재 다른 요청 처리 중입니다. 락 획득 실패"),
 	;
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/config/RedissonConfiguration.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/config/RedissonConfiguration.java
@@ -1,0 +1,27 @@
+package com.yeoljeong.tripmate.matching.infrastructure.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfiguration {
+
+	@Value("${spring.data.redis.host}")
+	private String host;
+
+	@Value("${spring.data.redis.port}")
+	private int port;
+
+	@Bean
+	public RedissonClient redissonClient() {
+		Config config = new Config();
+		config.useSingleServer()
+			.setAddress("redis://" + host + ":" + port);
+		return Redisson.create(config);
+	}
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/message/MatchingOutboxDispatcher.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/message/MatchingOutboxDispatcher.java
@@ -1,5 +1,6 @@
 package com.yeoljeong.tripmate.matching.infrastructure.message;
 
+import com.yeoljeong.tripmate.common.aop.TripmateLock;
 import com.yeoljeong.tripmate.domain.constants.OutboxStatus;
 import com.yeoljeong.tripmate.matching.infrastructure.persistence.MatchingOutbox;
 import com.yeoljeong.tripmate.matching.infrastructure.persistence.jpa.MatchingOutboxRepository;
@@ -19,8 +20,9 @@ public class MatchingOutboxDispatcher {
 	private final MatchingOutboxRepository matchingOutboxRepository;
 	private final KafkaTemplate<String, String> kafkaTemplate;
 
-	@Scheduled(fixedDelay = 5000)
+	@Scheduled(fixedDelay = 3000)
 	@Transactional
+	@TripmateLock(key = "'matching:outbox:dispatcher'")
 	public void dispatch() {
 		List<MatchingOutbox> events = matchingOutboxRepository
 			.findTop100ByStatusOrderByCreatedAtAsc(OutboxStatus.PENDING);

--- a/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/redisson/RedissonLockService.java
+++ b/src/main/java/com/yeoljeong/tripmate/matching/infrastructure/redisson/RedissonLockService.java
@@ -1,0 +1,44 @@
+package com.yeoljeong.tripmate.matching.infrastructure.redisson;
+
+import static com.yeoljeong.tripmate.matching.domain.exception.MatchingErrorCode.MATCHING_LOCK_FAILED;
+
+import com.yeoljeong.tripmate.exception.BusinessException;
+import com.yeoljeong.tripmate.matching.application.aop.MatchingLockService;
+import com.yeoljeong.tripmate.matching.domain.exception.MatchingErrorCode;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RedissonLockService implements MatchingLockService {
+
+	private final RedissonClient redissonClient;
+
+	@Override
+	public void lock(String key, long tryLockTime, long leaseTime) {
+		RLock lock = redissonClient.getLock(key);
+		log.debug("[MatchingLock] lock 시도 - key: {}", key);
+		try {
+			boolean isLock = lock.tryLock(tryLockTime, leaseTime, TimeUnit.MILLISECONDS);
+			if (!isLock) {
+				log.error("[MatchingLock] lock 획득 실패 - key: {}", key);
+				throw new BusinessException(MATCHING_LOCK_FAILED);
+			}
+		} catch (BusinessException e) {
+			throw e;
+		} catch (Exception e) {
+			log.error("[MatchingLock] redis lock 오류 - key: {}", key, e);
+		}
+	}
+
+	@Override
+	public void unlock(String key) {
+		log.debug("[MatchingLock] lock 해제 - key: {}", key);
+		redissonClient.getLock(key).unlock();
+	}
+}

--- a/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/message/UserSettingOutboxDispatcher.java
+++ b/src/main/java/com/yeoljeong/tripmate/usersetting/infrastructure/message/UserSettingOutboxDispatcher.java
@@ -1,5 +1,6 @@
 package com.yeoljeong.tripmate.usersetting.infrastructure.message;
 
+import com.yeoljeong.tripmate.common.aop.TripmateLock;
 import com.yeoljeong.tripmate.domain.constants.OutboxStatus;
 import com.yeoljeong.tripmate.usersetting.infrastructure.persistence.UserSettingOutbox;
 import com.yeoljeong.tripmate.usersetting.infrastructure.persistence.jpa.UserSettingOutboxRepository;
@@ -19,8 +20,9 @@ public class UserSettingOutboxDispatcher {
 	private final UserSettingOutboxRepository outboxRepository;
 	private final KafkaTemplate<String, String> kafkaTemplate;
 
-	@Scheduled(fixedDelay = 5000)
+	@Scheduled(fixedDelay = 3000)
 	@Transactional
+	@TripmateLock(key = "'user-setting:outbox:dispatcher'")
 	public void dispatch() {
 		List<UserSettingOutbox> pendingEvents = outboxRepository
 			.findTop100ByStatusOrderByCreatedAtAsc(OutboxStatus.PENDING);


### PR DESCRIPTION
### summary
- 매칭 수락 동시성 보장 및 Outbox Dispatcher 중복 발행 방지를 위해 Redisson 기반 분산락을 도입했습니다. `@TripmateLock` 어노테이션과 AOP를 활용해 비즈니스 로직과 락 처리를 분리했으며, 인터페이스 분리를 통해 Redisson 구현체 교체 시 application 계층 변경 없이 infrastructure 계층만 수정하면 되는 구조로 설계했습니다.

### changes
- **추가** `@TripmateLock` 어노테이션 — common 모듈, `key`(SpEL), `tryLockTime`(default 5000ms), `leaseTime`(default 15000ms) 파라미터
- **추가** `MatchingLockService` 인터페이스 — application 계층, `lock()` / `unlock()` 정의
- **추가** `RedissonLockService` — infrastructure/redisson, `MatchingLockService` 구현체
- **추가** `RedissonConfig` — `RedissonClient` 빈 등록
- **추가** `TripmateLockAspect` — `@TripmateLock` 감지, SpEL로 key 파싱, lock → proceed → unlock 처리
- **수정** `MatchingCommandService.accept()` — `@TripmateLock(key = "'matching:accept:' + #matchingId")` 적용, 락 범위를 도메인 상태 변경으로 최소화
- **수정** `OutboxDispatcher` — `@TripmateLock(key = "'matching:outbox:dispatcher'")` 적용, 다중 인스턴스 환경에서 중복 발행 방지

### background
- Outbox Dispatcher 키를 `matching:outbox:dispatcher`로 서비스명을 prefix로 붙였습니다. `outbox:dispatcher`로 하면 모든 MSA 서비스가 같은 Redis 키를 공유하게 되어 서비스 간 락 충돌이 발생합니다.